### PR TITLE
feat: add `seamless verify` auth-conformance harness

### DIFF
--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -13,6 +13,7 @@ USAGE
   seamless init [project-name]
   seamless check
   seamless bootstrap-admin [email]
+  seamless verify [--filter=<flow>] [--keep-up]
   seamless --help
   seamless --version
 
@@ -31,6 +32,11 @@ COMMANDS
 
   check
     Validate project setup, Docker, and running services
+
+  verify [--filter=<flow>] [--keep-up]
+    Stand up the auth stack and run the conformance suite across every
+    auth flow (API + SDK paths). Requires Docker. Set SEAMLESS_API_DIR and
+    SEAMLESS_ADAPTER_DIR to local source checkouts.
 
   bootstrap-admin [email]
     Create a bootstrap admin invite

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,10 +5,7 @@ import { generateReactStarter } from "../generators/frontend/react.js";
 import { generateExpressStarter } from "../generators/backend/express.js";
 import { generateAuthServer } from "../generators/auth/auth.js";
 import { configureApiEnv, configureWebEnv } from "../core/configure.js";
-import {
-  configureAuthLocalEnv,
-  generateDockerCompose,
-} from "../generators/docker/docker.js";
+import { generateDockerCompose } from "../generators/docker/docker.js";
 import { printSuccessOutput } from "../core/output.js";
 import { generateSeamlessConfig } from "../generators/config/config.js";
 
@@ -51,9 +48,7 @@ export async function runCLI(projectName?: string) {
   let sharedConfig: any = {};
 
   if (answers.authMode === "local") {
-    await generateAuthServer({ root }, "local");
-
-    sharedConfig = await configureAuthLocalEnv(root);
+    sharedConfig = await generateAuthServer({ root }, "local");
   }
 
   if (answers.useDocker) {

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -1,0 +1,117 @@
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+import kleur from "kleur";
+
+import { runCommand } from "../core/exec.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const VERIFY_DIR = path.join(REPO_ROOT, "verify");
+const COMPOSE_FILE = path.join(VERIFY_DIR, "docker-compose.verify.yml");
+const HARNESS_DIR = path.join(VERIFY_DIR, "harness");
+
+interface VerifyOptions {
+  released: boolean;
+  keepUp: boolean;
+  grep?: string;
+}
+
+function parseArgs(args: string[]): VerifyOptions {
+  return {
+    released: args.includes("--released"),
+    keepUp: args.includes("--keep-up"),
+    grep: args.find((a) => a.startsWith("--filter="))?.split("=")[1],
+  };
+}
+
+function ensureDocker(): void {
+  try {
+    execSync("docker --version", { stdio: "ignore" });
+  } catch {
+    throw new Error(
+      "Docker is required for `seamless verify`. Install: https://docs.docker.com/get-docker/",
+    );
+  }
+}
+
+function resolveSourceDirs(): { apiDir: string; adapterDir: string } {
+  const apiDir = process.env.SEAMLESS_API_DIR;
+  const adapterDir = process.env.SEAMLESS_ADAPTER_DIR;
+  if (!apiDir || !adapterDir) {
+    throw new Error(
+      "Set SEAMLESS_API_DIR and SEAMLESS_ADAPTER_DIR to local source checkouts.\n" +
+        "  (Released-mode auto-clone lands in a later milestone.)",
+    );
+  }
+  return { apiDir, adapterDir };
+}
+
+export async function runVerify(args: string[] = []): Promise<void> {
+  const opts = parseArgs(args);
+  console.log(kleur.bold("\nSeamless Verify — auth conformance\n"));
+
+  if (opts.released) {
+    console.log(kleur.yellow("--released mode is not implemented yet; running --local.\n"));
+  }
+
+  ensureDocker();
+  const { apiDir, adapterDir } = resolveSourceDirs();
+
+  const serviceToken = process.env.API_SERVICE_TOKEN ?? "verify-dev-service-token";
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    SEAMLESS_API_DIR: apiDir,
+    SEAMLESS_ADAPTER_DIR: adapterDir,
+    API_SERVICE_TOKEN: serviceToken,
+    JWKS_KID: process.env.JWKS_KID ?? "dev-main",
+    SEAMLESS_BOOTSTRAP_SECRET:
+      process.env.SEAMLESS_BOOTSTRAP_SECRET ?? "verify-dev-bootstrap-secret",
+    // consumed by the harness
+    SEAMLESS_API_SERVICE_TOKEN: serviceToken,
+    SEAMLESS_API_URL: "http://localhost:5312",
+  };
+
+  let failed = false;
+  try {
+    console.log(kleur.cyan("→ Building & starting the stack (postgres + auth-api)…"));
+    await runCommand(
+      "docker",
+      ["compose", "-f", COMPOSE_FILE, "up", "-d", "--build", "postgres", "auth-api"],
+      VERIFY_DIR,
+      env,
+    );
+
+    if (!fs.existsSync(path.join(HARNESS_DIR, "node_modules"))) {
+      console.log(kleur.cyan("→ Installing harness dependencies…"));
+      await runCommand("npm", ["install"], HARNESS_DIR, env);
+    }
+
+    console.log(kleur.cyan("→ Running the conformance harness…\n"));
+    const testArgs = ["test", "--", "--project=api"];
+    if (opts.grep) testArgs.push("--grep", opts.grep);
+    await runCommand("npm", testArgs, HARNESS_DIR, env);
+
+    console.log(kleur.green("\n✔ Conformance passed.\n"));
+  } catch (err) {
+    failed = true;
+    console.log(kleur.red(`\n✖ Conformance failed: ${(err as Error).message}\n`));
+  } finally {
+    if (opts.keepUp) {
+      console.log(kleur.dim("Stack left running (--keep-up). Tear down with:"));
+      console.log(kleur.dim(`  docker compose -f ${COMPOSE_FILE} down -v\n`));
+    } else {
+      console.log(kleur.cyan("→ Tearing down…"));
+      await runCommand(
+        "docker",
+        ["compose", "-f", COMPOSE_FILE, "down", "-v"],
+        VERIFY_DIR,
+        env,
+      ).catch(() => undefined);
+    }
+  }
+
+  if (failed) process.exit(1);
+}

--- a/src/core/bootstrapSecret.ts
+++ b/src/core/bootstrapSecret.ts
@@ -5,21 +5,21 @@ export function resolveBootstrapSecret(): string | null {
   const root = process.cwd();
 
   if (process.env.SEAMLESS_BOOTSTRAP_SECRET) {
-    return process.env.SEAMLESS_BOOTSTRAP_SECRET;
+    return normalizeSecretValue(process.env.SEAMLESS_BOOTSTRAP_SECRET);
   }
 
   const rootEnv = path.join(root, ".env");
   if (fs.existsSync(rootEnv)) {
     const content = fs.readFileSync(rootEnv, "utf-8");
     const match = content.match(/SEAMLESS_BOOTSTRAP_SECRET=(.*)/);
-    if (match) return match[1].trim();
+    if (match) return normalizeSecretValue(match[1]);
   }
 
   const authEnv = path.join(root, "auth", ".env");
   if (fs.existsSync(authEnv)) {
     const content = fs.readFileSync(authEnv, "utf-8");
     const match = content.match(/SEAMLESS_BOOTSTRAP_SECRET=(.*)/);
-    if (match) return match[1].trim();
+    if (match) return normalizeSecretValue(match[1]);
   }
 
   const compose = path.join(root, "docker-compose.yml");
@@ -27,8 +27,21 @@ export function resolveBootstrapSecret(): string | null {
     const content = fs.readFileSync(compose, "utf-8");
 
     const match = content.match(/SEAMLESS_BOOTSTRAP_SECRET:\s*(.*)/);
-    if (match) return match[1].trim();
+    if (match) return normalizeSecretValue(match[1]);
   }
 
   return null;
+}
+
+function normalizeSecretValue(value: string): string {
+  const trimmed = value.trim();
+
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+
+  return trimmed;
 }

--- a/src/core/exec.ts
+++ b/src/core/exec.ts
@@ -4,12 +4,14 @@ export function runCommand(
   command: string,
   args: string[],
   cwd: string,
+  env?: NodeJS.ProcessEnv,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       stdio: "inherit",
       cwd,
       shell: true,
+      env: env ?? process.env,
     });
 
     child.on("close", (code) => {

--- a/src/core/fetch.ts
+++ b/src/core/fetch.ts
@@ -1,6 +1,8 @@
+import { SEAMLESS_AUTH_API_VERSION } from "./images.js";
+
 export async function fetchEnvExample(): Promise<string> {
   const url =
-    "https://raw.githubusercontent.com/fells-code/seamless-auth-api/main/.env.example";
+    `https://raw.githubusercontent.com/fells-code/seamless-auth-api/${SEAMLESS_AUTH_API_VERSION}/.env.example`;
 
   const res = await fetch(url);
 

--- a/src/core/images.ts
+++ b/src/core/images.ts
@@ -1,0 +1,9 @@
+export const POSTGRES_IMAGE = "postgres:17";
+
+export const SEAMLESS_AUTH_API_VERSION = "v0.2.1";
+
+export const SEAMLESS_AUTH_API_IMAGE = `ghcr.io/fells-code/seamless-auth-api:${SEAMLESS_AUTH_API_VERSION}`;
+
+export const SEAMLESS_AUTH_ADMIN_DASHBOARD_VERSION = "v0.1.0";
+
+export const SEAMLESS_AUTH_ADMIN_DASHBOARD_IMAGE = `ghcr.io/fells-code/seamless-auth-admin-dashboard:${SEAMLESS_AUTH_ADMIN_DASHBOARD_VERSION}`;

--- a/src/generators/auth/auth.ts
+++ b/src/generators/auth/auth.ts
@@ -1,10 +1,16 @@
 import fs from "fs";
 import path from "path";
+import { parseEnvString } from "../../core/env.js";
 import { runCommand } from "../../core/exec.js";
-import { writeEnv } from "../../utils/writeEnv.js";
+import { fetchEnvExample } from "../../core/fetch.js";
+import { POSTGRES_IMAGE, SEAMLESS_AUTH_API_IMAGE } from "../../core/images.js";
+import {
+  buildAuthEnv,
+  configureAuthLocalEnv,
+  envToDockerBlock,
+} from "../docker/docker.js";
 
 const AUTH_REPO = "https://github.com/fells-code/seamless-auth-api";
-const AUTH_PORT = 5312;
 
 export async function generateAuthServer(
   context: any,
@@ -13,10 +19,10 @@ export async function generateAuthServer(
   const { root } = context;
 
   if (mode === "local") {
-    await setupLocalAuth(root);
-  } else {
-    await setupDockerAuth(root);
+    return await setupLocalAuth(root);
   }
+
+  return await setupDockerAuth(root);
 }
 
 async function setupLocalAuth(root: string) {
@@ -28,31 +34,52 @@ async function setupLocalAuth(root: string) {
 
   console.log("Writing auth environment...");
 
-  writeEnv(authDir, {
-    PORT: AUTH_PORT,
-    NODE_ENV: "development",
-    AUTH_MODE: "server",
-    ISSUER: `http://localhost:${AUTH_PORT}`,
-  });
+  const shared = await configureAuthLocalEnv(root);
 
   console.log("Auth server ready in /auth");
+  return shared;
 }
 
 async function setupDockerAuth(root: string) {
   console.log("Creating docker-compose for SeamlessAuth...");
 
+  const raw = await fetchEnvExample();
+  const parsed = parseEnvString(raw);
+  const { env, shared } = buildAuthEnv(parsed, "docker");
+  const envBlock = envToDockerBlock(env);
+
   const dockerCompose = `
 services:
+  db:
+    image: ${POSTGRES_IMAGE}
+    container_name: seamless-db
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: myuser
+      POSTGRES_PASSWORD: mypassword
+      POSTGRES_DB: postgres
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U myuser -d postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   auth:
-    image: ghcr.io/fells-code/seamless-auth-api:v0.1.2
+    image: ${SEAMLESS_AUTH_API_IMAGE}
     container_name: seamless-auth
     ports:
       - "5312:5312"
     environment:
-      PORT: 5312
-      NODE_ENV: development
-      AUTH_MODE: server
-      ISSUER: http://localhost:5312
+${envBlock}
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  pgdata:
 `;
 
   fs.writeFileSync(
@@ -61,4 +88,5 @@ services:
   );
 
   console.log("Docker setup ready.");
+  return shared;
 }

--- a/src/generators/config/config.ts
+++ b/src/generators/config/config.ts
@@ -1,6 +1,10 @@
 import fs from "fs";
 import path from "path";
 import { VERSION } from "../../index.js";
+import {
+  SEAMLESS_AUTH_ADMIN_DASHBOARD_IMAGE,
+  SEAMLESS_AUTH_API_IMAGE,
+} from "../../core/images.js";
 
 export function generateSeamlessConfig(
   root: string,
@@ -28,17 +32,14 @@ export function generateSeamlessConfig(
       },
       auth: {
         mode: options.authMode,
-        image:
-          options.authMode === "docker"
-            ? "ghcr.io/fells-code/seamless-auth-api:latest"
-            : null,
+        image: options.authMode === "docker" ? SEAMLESS_AUTH_API_IMAGE : null,
         path: options.authMode === "local" ? "./auth" : null,
       },
       admin: {
         mode: options.adminMode,
         image:
           options.adminMode === "image"
-            ? "ghcr.io/fells-code/seamless-auth-admin-dashboard:latest"
+            ? SEAMLESS_AUTH_ADMIN_DASHBOARD_IMAGE
             : null,
         path: options.adminMode === "source" ? "./admin" : null,
       },

--- a/src/generators/docker/docker.ts
+++ b/src/generators/docker/docker.ts
@@ -4,6 +4,11 @@ import { fetchEnvExample } from "../../core/fetch.js";
 import { parseEnv, parseEnvString } from "../../core/env.js";
 import { generateSecret } from "../../core/secrets.js";
 import { generateJWKS } from "../../core/jwks.js";
+import {
+  POSTGRES_IMAGE,
+  SEAMLESS_AUTH_ADMIN_DASHBOARD_IMAGE,
+  SEAMLESS_AUTH_API_IMAGE,
+} from "../../core/images.js";
 
 export async function generateDockerCompose(
   root: string,
@@ -40,7 +45,7 @@ async function buildCompose(
     compose: `
 services:
   db:
-    image: postgres:16
+    image: ${POSTGRES_IMAGE}
     container_name: seamless-db
     ports:
       - "5432:5432"
@@ -50,6 +55,11 @@ services:
       POSTGRES_DB: postgres
     volumes:
       - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U myuser -d postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
 ${authBlock}
 
@@ -87,7 +97,8 @@ async function authService(mode: "local" | "docker", root: string) {
       - ./auth:/app
       - /app/node_modules
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 `,
       shared,
     };
@@ -115,8 +126,10 @@ function apiService(shared: any) {
       - ./api:/app
       - /app/node_modules
     depends_on:
-      - db
-      - auth
+      db:
+        condition: service_healthy
+      auth:
+        condition: service_started
 `;
 }
 
@@ -148,14 +161,15 @@ async function authServiceDocker() {
   return {
     service: `
   auth:
-    image: ghcr.io/fells-code/seamless-auth-api:latest
+    image: ${SEAMLESS_AUTH_API_IMAGE}
     container_name: seamless-auth
     ports:
       - "5312:5312"
     environment:
 ${envBlock}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 `,
     shared,
   };
@@ -182,7 +196,7 @@ function adminService(mode: "image" | "source") {
 
   return `
   admin:
-    image: ghcr.io/fells-code/seamless-auth-admin-dashboard:latest
+    image: ${SEAMLESS_AUTH_ADMIN_DASHBOARD_IMAGE}
     container_name: admin
     ports:
       - "5174:80"
@@ -193,9 +207,13 @@ function adminService(mode: "image" | "source") {
 `;
 }
 
-function buildAuthEnv(env: Record<string, string>, mode: "local" | "docker") {
+export function buildAuthEnv(
+  env: Record<string, string>,
+  mode: "local" | "docker",
+) {
   const apiToken = generateSecret(32);
   const bootstrapSecret = generateSecret(32);
+  const kid = "dev-main";
 
   env.SEAMLESS_BOOTSTRAP_ENABLED = "true";
   env.SEAMLESS_BOOTSTRAP_SECRET = bootstrapSecret;
@@ -204,30 +222,16 @@ function buildAuthEnv(env: Record<string, string>, mode: "local" | "docker") {
   env.NODE_ENV = "development";
 
   env.AUTH_MODE = "server";
-  env.ISSUER = "http://auth:5312";
+  env.ISSUER =
+    mode === "docker" ? "http://auth:5312" : "http://localhost:5312";
 
   env.DB_HOST = mode === "docker" ? "db" : "localhost";
   env.DB_PORT = "5432";
 
   env.API_SERVICE_TOKEN = apiToken;
 
-  let kid = "main";
-  env.JWKS_ACTIVE_KID = kid;
-
-  if (mode === "docker") {
-    const jwks = buildJWKSConfig();
-
-    kid = jwks.kid;
-
-    env.SEAMLESS_JWKS_ACTIVE_KID = jwks.kid;
-    env.JWKS_ACTIVE_KID = jwks.kid;
-
-    env[`SEAMLESS_JWKS_KEY_${jwks.kid}_PRIVATE`] = jwks.privateKey;
-    env.JWKS_PUBLIC_KEYS = jwks.publicJwksJson;
-  }
-
   env.APP_ORIGINS = "http://localhost:3000";
-  env.ORIGINS = "http://localhost:5173";
+  env.ORIGINS = "http://localhost:5173,http://localhost:5174";
 
   return {
     env,
@@ -246,7 +250,7 @@ export function envToDockerBlock(env: Record<string, string>) {
         return `      ${k}: |\n${indentMultiline(v, 8)}`;
       }
 
-      return `      ${k}: ${v}`;
+      return `      ${k}: ${JSON.stringify(v)}`;
     })
     .join("\n");
 }
@@ -325,6 +329,6 @@ export function extractSharedFromExistingEnv(root: string) {
 
   return {
     apiToken: env.API_SERVICE_TOKEN,
-    kid: env.JWKS_ACTIVE_KID || "main",
+    kid: env.SEAMLESS_JWKS_ACTIVE_KID || env.JWKS_ACTIVE_KID || "dev-main",
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { runCheck } from "./commands/check.js";
 import { printHelp } from "./commands/help.js";
 import pkg from "../package.json" with { type: "json" };
 import { runBootstrapAdmin } from "./commands/bootstrapAdmin.js";
+import { runVerify } from "./commands/verify.js";
 
 export const VERSION = pkg.version;
 const args = process.argv.slice(2);
@@ -41,6 +42,11 @@ async function main() {
   if (command === "bootstrap-admin") {
     const email = args[1];
     await runBootstrapAdmin(email);
+    return;
+  }
+
+  if (command === "verify") {
+    await runVerify(args.slice(1));
     return;
   }
 

--- a/verify/docker-compose.verify.yml
+++ b/verify/docker-compose.verify.yml
@@ -1,0 +1,93 @@
+# Conformance stack for `seamless verify`.
+# Brings up Postgres + the auth API + the Express adapter from local source
+# (paths supplied by the verify command via env) so the Playwright harness can
+# drive every auth flow. NODE_ENV=test enables the API's external-delivery seam
+# so OTP / magic-link tokens are returned in responses (no real email/SMS).
+#
+# Required env (the `seamless verify` command writes these into .env.verify):
+#   SEAMLESS_API_DIR      absolute path to seamless-auth-api source
+#   SEAMLESS_ADAPTER_DIR  absolute path to the express adapter source
+#   API_SERVICE_TOKEN     shared secret between API and adapter
+#   JWKS_KID              key id the adapter expects (must match the API's active kid)
+#   SEAMLESS_BOOTSTRAP_SECRET  bearer secret for POST /bootstrap/admin-invite
+
+name: seamless-verify
+
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: seamless
+      POSTGRES_PASSWORD: seamless
+      POSTGRES_DB: seamless_auth
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U seamless -d seamless_auth']
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  auth-api:
+    # Built with the production Dockerfile (compiles dist/), but run with
+    # NODE_ENV=test so signing keys auto-generate and prod-only env (JWKS keys)
+    # is skipped. validateEnvs.sh gates startup on the env below.
+    build:
+      context: ${SEAMLESS_API_DIR}
+      dockerfile: Dockerfile
+    ports:
+      - '5312:5312'
+    environment:
+      NODE_ENV: test
+      PORT: '5312'
+      APP_NAME: Seamless Verify
+      APP_ID: seamless-verify
+      APP_ORIGINS: http://localhost:3000,http://localhost:5173
+      ISSUER: http://localhost:5312
+      DEFAULT_ROLES: user
+      AVAILABLE_ROLES: user,admin
+      LOGIN_METHODS: passkey,magic_link,email_otp,phone_otp
+      DB_LOGGING: 'false'
+      ACCESS_TOKEN_TTL: 15m
+      REFRESH_TOKEN_TTL: 1h
+      RATE_LIMIT: '100000'
+      DELAY_AFTER: '100000'
+      RPID: localhost
+      ORIGINS: http://localhost:5173,http://localhost:3000
+      DB_HOST: postgres
+      DB_PORT: '5432'
+      DB_USER: seamless
+      DB_PASSWORD: seamless
+      DB_NAME: seamless_auth
+      API_SERVICE_TOKEN: ${API_SERVICE_TOKEN}
+      SEAMLESS_BOOTSTRAP_ENABLED: 'true'
+      SEAMLESS_BOOTSTRAP_SECRET: ${SEAMLESS_BOOTSTRAP_SECRET}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ['CMD', 'node', 'dist/healthCheck.js']
+      interval: 3s
+      timeout: 5s
+      retries: 40
+
+  adapter:
+    build:
+      context: ${SEAMLESS_ADAPTER_DIR}
+    ports:
+      - '3000:3000'
+    environment:
+      NODE_ENV: development
+      PORT: '3000'
+      AUTH_SERVER_URL: http://auth-api:5312
+      APP_ORIGIN: http://localhost:3000
+      UI_ORIGINS: http://localhost:5173
+      API_SERVICE_TOKEN: ${API_SERVICE_TOKEN}
+      COOKIE_SIGNING_KEY: ${API_SERVICE_TOKEN}
+      JWKS_KID: ${JWKS_KID}
+      DB_HOST: postgres
+      DB_PORT: '5432'
+      DB_USER: seamless
+      DB_PASSWORD: seamless
+      DB_NAME: seamless_app
+    depends_on:
+      auth-api:
+        condition: service_healthy

--- a/verify/harness/.gitignore
+++ b/verify/harness/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+results/
+test-results/
+playwright-report/
+.last-run.json

--- a/verify/harness/api/emailOtp.spec.ts
+++ b/verify/harness/api/emailOtp.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '../lib/fixtures';
+import { registerAndVerifyEmail, registerEmail, requestEmailOtp, verifyEmailOtp } from '../lib/flows';
+
+test.describe('email OTP (api)', () => {
+  test('register -> request OTP -> verify -> session issued', async ({ actor }) => {
+    const session = await registerAndVerifyEmail(actor.ctx, actor.email);
+    expect(session.token).toBeTruthy();
+    expect(session.refreshToken).toBeTruthy();
+  });
+
+  test('a wrong OTP code is rejected with 401', async ({ actor }) => {
+    const ephemeral = await registerEmail(actor.ctx, actor.email);
+    await requestEmailOtp(actor.ctx, ephemeral); // issue a real code we deliberately won't use
+    const res = await verifyEmailOtp(actor.ctx, ephemeral, 'ZZZZZZ');
+    expect(res.status()).toBe(401);
+  });
+});

--- a/verify/harness/api/magicLink.spec.ts
+++ b/verify/harness/api/magicLink.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '../lib/fixtures';
+import {
+  login,
+  pollMagicLink,
+  registerAndVerifyEmail,
+  requestMagicLink,
+  verifyMagicLink,
+} from '../lib/flows';
+
+test.describe('magic link (api)', () => {
+  test('request -> poll(waiting) -> verify -> poll issues a session', async ({ actor }) => {
+    await registerAndVerifyEmail(actor.ctx, actor.email); // user must exist + be verified
+    const ephemeral = await login(actor.ctx, actor.email);
+
+    const { token } = await requestMagicLink(actor.ctx, ephemeral);
+
+    // Polling before the link is verified must return 204 (still waiting) — never 500.
+    // This is the exact regression that created the otp-sanatization branch.
+    const pending = await pollMagicLink(actor.ctx, ephemeral);
+    expect(pending.status(), 'poll before verify is 204, not 500').toBe(204);
+
+    const verified = await verifyMagicLink(actor.ctx, token);
+    expect(verified.ok(), `verify -> ${verified.status()}`).toBeTruthy();
+
+    const completed = await pollMagicLink(actor.ctx, ephemeral);
+    expect(completed.status(), 'poll after verify issues a session').toBe(200);
+    const body = await completed.json();
+    expect(body.token, 'session access token').toBeTruthy();
+    expect(body.refreshToken, 'session refresh token').toBeTruthy();
+  });
+
+  test('an invalid magic-link token is rejected', async ({ actor }) => {
+    const res = await verifyMagicLink(actor.ctx, 'not-a-real-token');
+    expect(res.status()).toBe(400);
+  });
+});

--- a/verify/harness/api/sessionLifecycle.spec.ts
+++ b/verify/harness/api/sessionLifecycle.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '../lib/fixtures';
+import { listSessions, logout, refresh, registerAndVerifyEmail } from '../lib/flows';
+
+test.describe('session lifecycle (api)', () => {
+  test('refresh issues a new access token', async ({ actor }) => {
+    const { refreshToken } = await registerAndVerifyEmail(actor.ctx, actor.email);
+    const res = await refresh(actor.ctx, refreshToken);
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.token, 'refresh returns a new access token').toBeTruthy();
+  });
+
+  test('sessions list shows the active session; logout revokes it', async ({ actor }) => {
+    const { token } = await registerAndVerifyEmail(actor.ctx, actor.email);
+
+    const list = await listSessions(actor.ctx, token);
+    expect(list.status()).toBe(200);
+    expect((await list.json()).total).toBeGreaterThanOrEqual(1);
+
+    const out = await logout(actor.ctx, token);
+    expect(out.ok(), `logout -> ${out.status()}`).toBeTruthy();
+
+    const after = await listSessions(actor.ctx, token);
+    expect(after.status(), 'access token rejected after logout').toBe(401);
+  });
+});

--- a/verify/harness/global-setup.ts
+++ b/verify/harness/global-setup.ts
@@ -1,0 +1,35 @@
+import { request as playwrightRequest } from '@playwright/test';
+
+import { ADAPTER_URL, API_URL } from './lib/env';
+
+async function waitForHealth(url: string, name: string, timeoutMs = 120_000): Promise<void> {
+  const ctx = await playwrightRequest.newContext();
+  const start = Date.now();
+  let lastError = '';
+  try {
+    while (Date.now() - start < timeoutMs) {
+      try {
+        const res = await ctx.get(url);
+        if (res.ok()) {
+          // eslint-disable-next-line no-console
+          console.log(`✔ ${name} healthy (${url})`);
+          return;
+        }
+        lastError = `status ${res.status()}`;
+      } catch (err) {
+        lastError = err instanceof Error ? err.message : String(err);
+      }
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+  } finally {
+    await ctx.dispose();
+  }
+  throw new Error(`✖ ${name} not healthy at ${url} within ${timeoutMs}ms (last: ${lastError})`);
+}
+
+export default async function globalSetup(): Promise<void> {
+  await waitForHealth(`${API_URL}/health/status`, 'auth-api');
+  if (process.env.SEAMLESS_VERIFY_ADAPTER === '1') {
+    await waitForHealth(`${ADAPTER_URL}/`, 'adapter');
+  }
+}

--- a/verify/harness/lib/client.ts
+++ b/verify/harness/lib/client.ts
@@ -1,0 +1,25 @@
+import { APIRequestContext, request as playwrightRequest } from '@playwright/test';
+
+import { API_SERVICE_TOKEN, API_URL, uniqueClientIp, uniqueEmail } from './env';
+import { mintServiceToken } from './serviceToken';
+
+export interface Actor {
+  email: string;
+  ctx: APIRequestContext;
+  dispose: () => Promise<void>;
+}
+
+// An actor is one virtual user: a fresh request context bound to the API, with
+// its own client IP + service token applied to every request. This both isolates
+// rate-limit buckets and faithfully mirrors how the server adapter calls the API.
+export async function newApiActor(prefix = 'verify'): Promise<Actor> {
+  const ctx = await playwrightRequest.newContext({
+    baseURL: API_URL,
+    extraHTTPHeaders: {
+      'x-seamless-client-ip': uniqueClientIp(),
+      'x-seamless-service-token': `Bearer ${mintServiceToken(API_SERVICE_TOKEN)}`,
+    },
+  });
+
+  return { email: uniqueEmail(prefix), ctx, dispose: () => ctx.dispose() };
+}

--- a/verify/harness/lib/env.ts
+++ b/verify/harness/lib/env.ts
@@ -1,0 +1,31 @@
+// Shared config + helpers for the conformance harness.
+
+export const API_URL = process.env.SEAMLESS_API_URL ?? 'http://localhost:5312';
+export const ADAPTER_URL = process.env.SEAMLESS_ADAPTER_URL ?? 'http://localhost:3000';
+
+// Must match the API's API_SERVICE_TOKEN so the harness can mint M2M tokens.
+export const API_SERVICE_TOKEN =
+  process.env.SEAMLESS_API_SERVICE_TOKEN ?? 'verify-dev-service-token';
+
+// Non-production seam: makes the API return OTP / magic-link tokens in the
+// response `delivery` object instead of sending real email/SMS.
+export const EXTERNAL_DELIVERY = {
+  'x-seamless-auth-delivery-mode': 'external',
+} as const;
+
+const runId = process.env.SEAMLESS_RUN_ID ?? String(Date.now());
+
+let emailCounter = 0;
+export function uniqueEmail(prefix = 'verify'): string {
+  emailCounter += 1;
+  return `${prefix}.${runId}.${emailCounter}@example.test`;
+}
+
+// Distinct client IP per actor so the API's per-IP rate limiters see separate
+// buckets (honored only alongside a valid service token — see client.ts).
+let ipCounter = 0;
+export function uniqueClientIp(): string {
+  ipCounter += 1;
+  const n = ipCounter;
+  return `10.${(n >> 16) & 255}.${(n >> 8) & 255}.${n & 255}`;
+}

--- a/verify/harness/lib/fixtures.ts
+++ b/verify/harness/lib/fixtures.ts
@@ -1,0 +1,15 @@
+import { test as base } from '@playwright/test';
+
+import { Actor, newApiActor } from './client';
+
+// Provides an auto-created, auto-disposed `actor` (one virtual user with its own
+// API request context, client IP, and service token) to every test.
+export const test = base.extend<{ actor: Actor }>({
+  actor: async ({}, use) => {
+    const actor = await newApiActor();
+    await use(actor);
+    await actor.dispose();
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/verify/harness/lib/flows.ts
+++ b/verify/harness/lib/flows.ts
@@ -1,0 +1,104 @@
+import { APIRequestContext, expect } from '@playwright/test';
+
+import { EXTERNAL_DELIVERY } from './env';
+
+export interface SessionTokens {
+  token: string; // signed access token
+  refreshToken: string; // opaque refresh token
+  sub?: string;
+}
+
+function bearer(token: string) {
+  return { Authorization: `Bearer ${token}` };
+}
+
+// All helpers take an actor's request context (baseURL = API, with client-IP +
+// service-token headers already applied). Paths are therefore relative.
+
+/** Register a new email user; returns the ephemeral (pre-auth) token. */
+export async function registerEmail(ctx: APIRequestContext, email: string): Promise<string> {
+  const res = await ctx.post('/registration/register', {
+    headers: EXTERNAL_DELIVERY,
+    data: { email },
+  });
+  expect(res.ok(), `register ${email} -> ${res.status()} ${await res.text()}`).toBeTruthy();
+  const body = await res.json();
+  expect(body.token, 'register returns an ephemeral token').toBeTruthy();
+  return body.token as string;
+}
+
+/** Generate an email OTP and return the raw code via the external-delivery seam. */
+export async function requestEmailOtp(ctx: APIRequestContext, ephemeral: string): Promise<string> {
+  const res = await ctx.get('/otp/generate-email-otp', {
+    headers: { ...bearer(ephemeral), ...EXTERNAL_DELIVERY },
+  });
+  expect(res.ok(), `generate-email-otp -> ${res.status()} ${await res.text()}`).toBeTruthy();
+  const code = (await res.json())?.delivery?.token;
+  expect(code, 'external delivery returns the OTP code').toBeTruthy();
+  return String(code);
+}
+
+export function verifyEmailOtp(ctx: APIRequestContext, ephemeral: string, code: string) {
+  return ctx.post('/otp/verify-email-otp', {
+    headers: bearer(ephemeral),
+    data: { verificationToken: code },
+  });
+}
+
+/** Full email-OTP registration -> verified session tokens. */
+export async function registerAndVerifyEmail(
+  ctx: APIRequestContext,
+  email: string,
+): Promise<SessionTokens> {
+  const ephemeral = await registerEmail(ctx, email);
+  const code = await requestEmailOtp(ctx, ephemeral);
+  const res = await verifyEmailOtp(ctx, ephemeral, code);
+  expect(res.ok(), `verify-email-otp -> ${res.status()} ${await res.text()}`).toBeTruthy();
+  const body = await res.json();
+  expect(body.token, 'verify returns an access token').toBeTruthy();
+  expect(body.refreshToken, 'verify returns a refresh token').toBeTruthy();
+  return { token: body.token, refreshToken: body.refreshToken, sub: body.sub };
+}
+
+/** Begin a login; returns the ephemeral (pre-auth) token. */
+export async function login(ctx: APIRequestContext, identifier: string): Promise<string> {
+  const res = await ctx.post('/login', { data: { identifier } });
+  expect(res.ok(), `login ${identifier} -> ${res.status()} ${await res.text()}`).toBeTruthy();
+  const body = await res.json();
+  expect(body.token, 'login returns an ephemeral token').toBeTruthy();
+  return body.token as string;
+}
+
+/** Request a magic link; returns the raw token + URL via external delivery. */
+export async function requestMagicLink(
+  ctx: APIRequestContext,
+  ephemeral: string,
+): Promise<{ token: string; magicLinkUrl: string }> {
+  const res = await ctx.get('/magic-link', {
+    headers: { ...bearer(ephemeral), ...EXTERNAL_DELIVERY },
+  });
+  expect(res.ok(), `magic-link request -> ${res.status()} ${await res.text()}`).toBeTruthy();
+  const body = await res.json();
+  expect(body?.delivery?.token, 'external delivery returns the magic-link token').toBeTruthy();
+  return { token: body.delivery.token, magicLinkUrl: body.delivery.magicLinkUrl };
+}
+
+export function verifyMagicLink(ctx: APIRequestContext, rawToken: string) {
+  return ctx.get(`/magic-link/verify/${rawToken}`);
+}
+
+export function pollMagicLink(ctx: APIRequestContext, ephemeral: string) {
+  return ctx.get('/magic-link/check', { headers: bearer(ephemeral) });
+}
+
+export function refresh(ctx: APIRequestContext, refreshToken: string) {
+  return ctx.post('/refresh', { headers: bearer(refreshToken) });
+}
+
+export function listSessions(ctx: APIRequestContext, accessToken: string) {
+  return ctx.get('/sessions', { headers: bearer(accessToken) });
+}
+
+export function logout(ctx: APIRequestContext, accessToken: string) {
+  return ctx.delete('/logout', { headers: bearer(accessToken) });
+}

--- a/verify/harness/lib/serviceToken.ts
+++ b/verify/harness/lib/serviceToken.ts
@@ -1,0 +1,26 @@
+import { createHmac } from 'crypto';
+
+function b64url(value: string): string {
+  return Buffer.from(value).toString('base64url');
+}
+
+// Mint an internal service token (HS256) the API trusts for client-IP
+// attribution — the same M2M mechanism the real server adapter uses.
+// Claims must be iss=seamless-portal-api, aud=seamless-auth (see the API's
+// authenticateServiceToken / trustedClientIp middleware).
+export function mintServiceToken(secret: string, sub = 'seamless-verify'): string {
+  const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const now = Math.floor(Date.now() / 1000);
+  const payload = b64url(
+    JSON.stringify({
+      sub,
+      iss: 'seamless-portal-api',
+      aud: 'seamless-auth',
+      iat: now,
+      exp: now + 3600,
+    }),
+  );
+  const data = `${header}.${payload}`;
+  const sig = createHmac('sha256', secret).update(data).digest('base64url');
+  return `${data}.${sig}`;
+}

--- a/verify/harness/package-lock.json
+++ b/verify/harness/package-lock.json
@@ -1,0 +1,93 @@
+{
+  "name": "seamless-verify-harness",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "seamless-verify-harness",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.49.0",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/verify/harness/package.json
+++ b/verify/harness/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "seamless-verify-harness",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Playwright conformance harness driven by `seamless verify`.",
+  "scripts": {
+    "test": "playwright test",
+    "test:api": "playwright test --project=api"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/verify/harness/playwright.config.ts
+++ b/verify/harness/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from '@playwright/test';
+
+// One runner, multiple projects. `api` and `adapter` hit HTTP directly (no
+// browser); `react` (added in M2) drives chromium. global-setup health-gates
+// the stack before any project runs.
+export default defineConfig({
+  testDir: '.',
+  globalSetup: './global-setup.ts',
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: false,
+  workers: 1,
+  reporter: [
+    ['list'],
+    ['junit', { outputFile: 'results/junit.xml' }],
+    ['html', { outputFolder: 'results/html', open: 'never' }],
+  ],
+  projects: [
+    { name: 'api', testMatch: /api\/.*\.spec\.ts$/ },
+    { name: 'adapter', testMatch: /adapter\/.*\.spec\.ts$/ },
+  ],
+});


### PR DESCRIPTION
## What

Adds `seamless verify` — a single command that stands up the auth stack and runs an automated **conformance suite** across the auth flows, then tears down. This is **M1 (API path)** of the cross-SDK conformance harness.

```
seamless verify            # build+start stack → run suite → teardown (exit≠0 on failure)
seamless verify --keep-up  # leave the stack running to inspect
seamless verify --filter=magic
```

## Why

The `seamless-auth-api` ⇄ `@seamless-auth/express` ⇄ `@seamless-auth/react` triad has broken silently before (magic-link sign-in regressed to a `500` during polling, caught only by hand). This harness validates the real flows against a **live stack** so such regressions fail a check instead of shipping.

## What's in it

- **`verify/docker-compose.verify.yml`** — Postgres + auth-api from local source. Built with the production `Dockerfile` but run with `NODE_ENV=test`, so signing keys auto-generate and the full `validateEnvs.sh` env set is satisfied.
- **`verify/harness/`** — one Playwright runner:
  - health-gating `global-setup`,
  - an **actor model**: each virtual user gets its own client IP + a minted HS256 service token, so per-IP rate-limit buckets stay isolated (the same M2M mechanism the real adapter uses),
  - `api` specs: email-OTP register→verify→session, **magic-link request→poll(204)→verify→poll(session)** (the exact regression), session lifecycle (refresh / sessions / logout).
- **`src/commands/verify.ts`** + `index.ts`/`help.ts` wiring; `runCommand` gains an optional `env` param.

## Verified

`seamless verify` runs green end-to-end locally — **6/6 api scenarios pass** against the live stack, then the stack tears down cleanly.

## Notes / scope

- **API path only** so far. The cookie-based **adapter path** and the **React / passkey / OAuth** projects are subsequent milestones (M1-adapter, M2–M5).
- Currently requires `SEAMLESS_API_DIR` and `SEAMLESS_ADAPTER_DIR` env vars; released-mode auto-clone is a later milestone.
- Includes one prior unrelated commit already on this branch (`chore: normalizing build patterns`).
