### PR TITLE
feat(verify): adapter (cookie) conformance path — harness adapter app + cookie cases

### DIFF
--- a/verify/docker-compose.verify.yml
+++ b/verify/docker-compose.verify.yml
@@ -36,12 +36,18 @@ services:
     ports:
       - '5312:5312'
     environment:
-      NODE_ENV: test
+      # `development` (not `test`): the API's JWKS endpoint only serves the
+      # auto-generated dev public key when NODE_ENV === 'development', even though
+      # signing treats any non-production env as dev. Running as development keeps
+      # JWKS publication working so the adapter/SDKs can verify tokens.
+      NODE_ENV: development
       PORT: '5312'
       APP_NAME: Seamless Verify
       APP_ID: seamless-verify
       APP_ORIGINS: http://localhost:3000,http://localhost:5173
-      ISSUER: http://localhost:5312
+      # Must equal the adapter's AUTH_SERVER_URL: the adapter validates the `iss`
+      # claim on API-signed tokens against the URL it reaches the API on.
+      ISSUER: http://auth-api:5312
       DEFAULT_ROLES: user
       AVAILABLE_ROLES: user,admin
       LOGIN_METHODS: passkey,magic_link,email_otp,phone_otp


### PR DESCRIPTION
## What

Adds the **adapter (cookie) path** to the `seamless verify` conformance harness, proving the real `@seamless-auth/express` SDK + cookie bridge work end-to-end against the auth API. Complements the API path already on main.

## Included

- **Harness adapter app** (`verify/adapter-app/`): a minimal adopter backend that mounts the real `@seamless-auth/express` with a **capture transport** + a `/__captured` readout, so the harness can read OTP/magic-link codes the adapter strips before responding to the browser. Dockerized; replaces the starter-express adapter in the verify compose.
- **`adapter` Playwright project** — an `adapterActor` (cookie-persisting request context), `adapterFlows`, and two green cases:
  - `register → verify email → login-OTP → seamless-access/refresh cookies → /users/me (200)`
  - `logout → 204 → session cleared`
- **Compose**: run the auth API as `development` (so it publishes the dev JWKS the adapter verifies) and align `ISSUER` to the adapter's `authServerUrl`.

## Run

```
# from verify/harness, against a running verify stack
SEAMLESS_VERIFY_ADAPTER=1 npx playwright test --project=adapter
```

Reproducible now that fells-code/seamless-auth-api#48 (makes `LOGIN_METHODS` authoritative) is merged — the adapter login-OTP flow needs `email_otp` enabled via env.

## Follow-ups (not in this PR)

- Wire the `adapter` project into the default `seamless verify` run (currently runs `--project=api`) and add `down -v` for a deterministic seed.
- Magic-link via the adapter has a known device-binding `403` on poll (narrowed to a likely user-agent-forwarding difference between request and poll) — under investigation, not yet covered.

## Verified

CLI builds clean; both adapter cases pass live against the stack.