### PR TITLE
feat(verify): adapter magic-link case + --local SDK linking

### DIFF
--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -33,10 +33,14 @@ COMMANDS
   check
     Validate project setup, Docker, and running services
 
-  verify [--api-only] [--filter=<flow>] [--keep-up]
+  verify [--local] [--api-only] [--filter=<flow>] [--keep-up]
     Stand up the auth stack and run the conformance suite across the API and
     the cookie (adapter) paths. Requires Docker. Builds the auth server from
     a sibling seamless-auth-api checkout (override with SEAMLESS_API_DIR).
+
+    --local builds and links the local @seamless-auth/* SDK source (sibling
+    seamless-auth-server, override with SEAMLESS_SERVER_DIR) instead of the
+    published npm packages — so you can catch SDK regressions before publishing.
 
   bootstrap-admin [email]
     Create a bootstrap admin invite

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -14,7 +14,7 @@ const COMPOSE_FILE = path.join(VERIFY_DIR, "docker-compose.verify.yml");
 const HARNESS_DIR = path.join(VERIFY_DIR, "harness");
 
 interface VerifyOptions {
-  released: boolean;
+  local: boolean;
   keepUp: boolean;
   apiOnly: boolean;
   grep?: string;
@@ -22,7 +22,7 @@ interface VerifyOptions {
 
 function parseArgs(args: string[]): VerifyOptions {
   return {
-    released: args.includes("--released"),
+    local: args.includes("--local"),
     keepUp: args.includes("--keep-up"),
     apiOnly: args.includes("--api-only"),
     grep: args.find((a) => a.startsWith("--filter="))?.split("=")[1],
@@ -53,17 +53,51 @@ function resolveApiDir(): string {
   return candidate;
 }
 
+const VENDOR_DIR = path.join(VERIFY_DIR, "adapter-app", "vendor");
+
+// The local server SDK (@seamless-auth/core + /express). Defaults to a sibling
+// checkout; override with SEAMLESS_SERVER_DIR. Only needed for --local.
+function resolveServerDir(): string {
+  const candidate =
+    process.env.SEAMLESS_SERVER_DIR ?? path.resolve(REPO_ROOT, "..", "seamless-auth-server");
+  if (!fs.existsSync(path.join(candidate, "pnpm-workspace.yaml"))) {
+    throw new Error(
+      `Could not find seamless-auth-server at ${candidate}.\n` +
+        "  Set SEAMLESS_SERVER_DIR to its local checkout (needed for --local).",
+    );
+  }
+  return candidate;
+}
+
+function cleanVendor(): void {
+  for (const f of fs.readdirSync(VENDOR_DIR)) {
+    if (f.endsWith(".tgz")) fs.rmSync(path.join(VENDOR_DIR, f));
+  }
+}
+
+async function packLocalSdks(env: NodeJS.ProcessEnv): Promise<void> {
+  const serverDir = resolveServerDir();
+  console.log(kleur.cyan("→ Building & packing local @seamless-auth/* (core, express)…"));
+  await runCommand("pnpm", ["--filter", "@seamless-auth/core", "build"], serverDir, env);
+  await runCommand("pnpm", ["--filter", "@seamless-auth/express", "build"], serverDir, env);
+  for (const pkg of ["@seamless-auth/core", "@seamless-auth/express"]) {
+    await runCommand(
+      "pnpm",
+      ["--filter", pkg, "pack", "--pack-destination", VENDOR_DIR],
+      serverDir,
+      env,
+    );
+  }
+}
+
 function compose(env: NodeJS.ProcessEnv, ...args: string[]): Promise<void> {
   return runCommand("docker", ["compose", "-f", COMPOSE_FILE, ...args], VERIFY_DIR, env);
 }
 
 export async function runVerify(args: string[] = []): Promise<void> {
   const opts = parseArgs(args);
-  console.log(kleur.bold("\nSeamless Verify — auth conformance\n"));
-
-  if (opts.released) {
-    console.log(kleur.yellow("--released mode is not implemented yet; running --local.\n"));
-  }
+  console.log(kleur.bold("\nSeamless Verify — auth conformance"));
+  console.log(kleur.dim(`SDK: ${opts.local ? "local (built from source)" : "released (npm)"}\n`));
 
   ensureDocker();
   const apiDir = resolveApiDir();
@@ -89,6 +123,10 @@ export async function runVerify(args: string[] = []): Promise<void> {
 
   let failed = false;
   try {
+    // The adapter image installs local @seamless-auth/* tarballs only when present.
+    cleanVendor();
+    if (opts.local) await packLocalSdks(env);
+
     // Fresh volumes each run → deterministic system_config seed (e.g. LOGIN_METHODS).
     console.log(kleur.cyan("→ Cleaning any previous stack…"));
     await compose(env, "down", "-v").catch(() => undefined);

--- a/verify/adapter-app/Dockerfile
+++ b/verify/adapter-app/Dockerfile
@@ -3,6 +3,12 @@ WORKDIR /app
 RUN apk add --no-cache curl
 COPY package.json ./
 RUN npm install
+# --local mode: install locally-built @seamless-auth/* tarballs over the registry
+# versions. vendor/ is empty in --released mode, so this is a no-op there.
+COPY vendor/ ./vendor/
+RUN if ls ./vendor/*.tgz >/dev/null 2>&1; then \
+      npm install ./vendor/seamless-auth-core-*.tgz ./vendor/seamless-auth-express-*.tgz; \
+    fi
 COPY server.mjs ./
 EXPOSE 3000
 CMD ["node", "server.mjs"]

--- a/verify/adapter-app/package.json
+++ b/verify/adapter-app/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Minimal adopter backend for the conformance harness — real @seamless-auth/express with a capture transport.",
   "dependencies": {
-    "@seamless-auth/express": "^0.5.3",
+    "@seamless-auth/express": "^0.5.4",
     "cookie-parser": "^1.4.6",
     "express": "^4.19.2"
   }

--- a/verify/adapter-app/vendor/.gitignore
+++ b/verify/adapter-app/vendor/.gitignore
@@ -1,0 +1,3 @@
+*.tgz
+!.gitkeep
+!.gitignore

--- a/verify/harness/adapter/magicLink.spec.ts
+++ b/verify/harness/adapter/magicLink.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '../lib/fixtures';
+import { loginViaMagicLink, registerAndVerifyEmail } from '../lib/adapterFlows';
+
+test.describe('magic link login (adapter, cookies)', () => {
+  test('register -> verify -> magic-link request/verify/poll -> session -> /users/me', async ({
+    adapterActor,
+  }) => {
+    await registerAndVerifyEmail(adapterActor.ctx, adapterActor.email);
+    await loginViaMagicLink(adapterActor.ctx, adapterActor.email);
+
+    const me = await adapterActor.ctx.get('/auth/users/me');
+    expect(me.status(), 'authenticated via magic-link session cookie').toBe(200);
+  });
+});

--- a/verify/harness/lib/adapterFlows.ts
+++ b/verify/harness/lib/adapterFlows.ts
@@ -35,3 +35,23 @@ export async function loginViaEmailOtp(ctx: APIRequestContext, email: string): P
   res = await ctx.post('/auth/otp/verify-login-email-otp', { data: { verificationToken: code } });
   expect(res.ok(), `verify-login-email-otp -> ${res.status()}`).toBeTruthy();
 }
+
+export async function loginViaMagicLink(ctx: APIRequestContext, email: string): Promise<void> {
+  let res = await ctx.post('/auth/login', { data: { identifier: email } });
+  expect(res.ok(), `login -> ${res.status()}`).toBeTruthy();
+
+  res = await ctx.get('/auth/magic-link');
+  expect(res.ok(), `magic-link request -> ${res.status()}`).toBeTruthy();
+  const token = await readCapturedCode(ctx, email);
+
+  // Polling before the link is verified must return 204 (still waiting).
+  const pending = await ctx.get('/auth/magic-link/check');
+  expect(pending.status(), 'poll before verify is 204').toBe(204);
+
+  res = await ctx.get(`/auth/magic-link/verify/${token}`);
+  expect(res.ok(), `verify magic link -> ${res.status()}`).toBeTruthy();
+
+  // Polling after verification issues the session (device binding must match).
+  const completed = await ctx.get('/auth/magic-link/check');
+  expect(completed.status(), 'poll after verify issues a session').toBe(200);
+}


### PR DESCRIPTION
## What

Adds the magic-link **adapter** (cookie) conformance case and a **`--local`** mode that runs the harness against the local `@seamless-auth/*` SDK source instead of the published npm packages.

## Magic-link adapter case

`register → verify → magic-link request → poll(204) → verify-link → poll → session cookie → /users/me`. This was a `403` against `@seamless-auth/express@0.5.3` (the poll handler didn't forward the internal service token, so the API attributed the adapter's container IP → device-binding mismatch). It passes against **0.5.4**, which ships the fix. Bumps the adapter-app floor to `^0.5.4`.

## `--local` mode (the other half of the plan)

```
seamless verify            # released: adapter uses published @seamless-auth/express (npm)
seamless verify --local    # local: builds+packs sibling seamless-auth-server source, links it
```

- Builds + `pnpm pack`s local `@seamless-auth/core` + `/express` into `verify/adapter-app/vendor/`; the adapter Dockerfile installs those tarballs over the registry version (no-op when `vendor/` is empty, i.e. released mode).
- `SEAMLESS_SERVER_DIR` overrides the sibling-checkout default.
- This is what turns *"caught after publish"* into *"caught before publish"*.

## Verified end-to-end (via `npm link`)

- `seamless verify` → **9/9** (adapter on published `0.5.4`).
- `seamless verify --local` → **9/9**; confirmed the adapter image installed the local source (`@seamless-auth/express@0.5.1`, `@seamless-auth/core@0.5.1`), not the registry version.

## Why this matters

The harness already proved its worth: it caught the magic-link poll-handler bug against the *released* `0.5.3`; `--local` would have caught it against source before publishing.