### PR TITLE
test(verify): complete request-layer auth flow conformance cases

### DIFF
--- a/verify/harness/adapter/sessionLifecycle.spec.ts
+++ b/verify/harness/adapter/sessionLifecycle.spec.ts
@@ -1,10 +1,13 @@
 import { expect, test } from '../lib/fixtures';
-import { loginViaEmailOtp, registerAndVerifyEmail } from '../lib/adapterFlows';
+import { loginViaMagicLink, registerAndVerifyEmail } from '../lib/adapterFlows';
 
 test.describe('session lifecycle (adapter, cookies)', () => {
   test('logout clears the session', async ({ adapterActor }) => {
+    // Establish the session via magic-link login: it sets the session cookie and
+    // uses the magic-link rate limiter, keeping this spec off the OTP limiter so
+    // the adapter project's aggregate OTP traffic stays under the per-IP cap.
     await registerAndVerifyEmail(adapterActor.ctx, adapterActor.email);
-    await loginViaEmailOtp(adapterActor.ctx, adapterActor.email);
+    await loginViaMagicLink(adapterActor.ctx, adapterActor.email);
 
     expect((await adapterActor.ctx.get('/auth/users/me')).status(), 'authenticated').toBe(200);
 

--- a/verify/harness/api/adminBootstrap.spec.ts
+++ b/verify/harness/api/adminBootstrap.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '../lib/fixtures';
+import {
+  createBootstrapInvite,
+  pollMagicLink,
+  registerWithBootstrapToken,
+  requestMagicLink,
+  verifyMagicLink,
+} from '../lib/flows';
+
+test.describe('admin bootstrap (api)', () => {
+  // The first-admin invite is single-use per DB (the API returns 410 once an
+  // admin exists), so this relies on the fresh DB `seamless verify` provisions.
+  test('invite -> register -> magic-link completion promotes the user to admin', async ({
+    actor,
+  }) => {
+    const inviteToken = await createBootstrapInvite(actor.ctx, actor.email);
+    const ephemeral = await registerWithBootstrapToken(actor.ctx, actor.email, inviteToken);
+
+    const { token } = await requestMagicLink(actor.ctx, ephemeral);
+    const verified = await verifyMagicLink(actor.ctx, token);
+    expect(verified.ok(), `verify -> ${verified.status()}`).toBeTruthy();
+
+    const completed = await pollMagicLink(actor.ctx, ephemeral);
+    expect(completed.status(), 'poll after verify issues a session').toBe(200);
+
+    const body = await completed.json();
+    expect(body.token, 'session access token').toBeTruthy();
+    const roles = (body.roles ?? []) as string[];
+    expect(
+      roles.includes('admin'),
+      `bootstrap promotion grants the admin role (got ${JSON.stringify(roles)})`,
+    ).toBeTruthy();
+  });
+});

--- a/verify/harness/api/jwks.spec.ts
+++ b/verify/harness/api/jwks.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '../lib/fixtures';
+
+test.describe('JWKS (api)', () => {
+  test('publishes the active signing key as a JWK', async ({ actor }) => {
+    const res = await actor.ctx.get('/.well-known/jwks.json');
+    expect(res.status(), 'JWKS endpoint is available').toBe(200);
+
+    const body = await res.json();
+    expect(Array.isArray(body.keys), 'has a keys array').toBeTruthy();
+
+    const key = body.keys.find((k: { kid?: string }) => k.kid === 'dev-main');
+    expect(key, 'publishes the dev-main signing key').toBeTruthy();
+    expect(key.kty).toBe('RSA');
+    expect(key.use).toBe('sig');
+    expect(key.alg).toBe('RS256');
+  });
+});

--- a/verify/harness/api/organizations.spec.ts
+++ b/verify/harness/api/organizations.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '../lib/fixtures';
+import { registerAndVerifyEmail } from '../lib/flows';
+
+test.describe('organizations (api)', () => {
+  test('create -> list -> switch active', async ({ actor }) => {
+    const { token } = await registerAndVerifyEmail(actor.ctx, actor.email);
+    const auth = { Authorization: `Bearer ${token}` };
+
+    const created = await actor.ctx.post('/organizations', {
+      headers: auth,
+      data: { name: 'Acme Inc' },
+    });
+    expect(created.ok(), `create org -> ${created.status()}`).toBeTruthy();
+    const orgId = (await created.json()).organization.id;
+    expect(orgId, 'create returns an organization id').toBeTruthy();
+
+    const list = await actor.ctx.get('/organizations', { headers: auth });
+    expect(list.ok()).toBeTruthy();
+    const orgs = (await list.json()).organizations as Array<{ id: string }>;
+    expect(orgs.some((o) => o.id === orgId), 'created org appears in the list').toBeTruthy();
+
+    const switched = await actor.ctx.post(`/organizations/${orgId}/switch`, {
+      headers: auth,
+      data: {},
+    });
+    expect(switched.ok(), `switch org -> ${switched.status()}`).toBeTruthy();
+  });
+});

--- a/verify/harness/api/phoneOtp.spec.ts
+++ b/verify/harness/api/phoneOtp.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '../lib/fixtures';
+import { uniquePhone } from '../lib/env';
+import { registerWithPhone, requestPhoneOtp, verifyPhoneOtp } from '../lib/flows';
+
+test.describe('phone OTP (api)', () => {
+  test('register with phone -> request OTP -> verify', async ({ actor }) => {
+    const ephemeral = await registerWithPhone(actor.ctx, actor.email, uniquePhone());
+    const code = await requestPhoneOtp(actor.ctx, ephemeral);
+    const res = await verifyPhoneOtp(actor.ctx, ephemeral, code);
+    expect(res.ok(), `verify-phone-otp -> ${res.status()}`).toBeTruthy();
+  });
+
+  test('a wrong phone OTP code is rejected with 401', async ({ actor }) => {
+    const ephemeral = await registerWithPhone(actor.ctx, actor.email, uniquePhone());
+    await requestPhoneOtp(actor.ctx, ephemeral); // issue a real code we deliberately won't use
+    const res = await verifyPhoneOtp(actor.ctx, ephemeral, '000000');
+    expect(res.status()).toBe(401);
+  });
+});

--- a/verify/harness/api/totp.spec.ts
+++ b/verify/harness/api/totp.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '../lib/fixtures';
+import { registerAndVerifyEmail } from '../lib/flows';
+import { totp } from '../lib/totp';
+
+test.describe('TOTP (api)', () => {
+  test('enroll -> verify enrollment with a computed code -> status enabled', async ({ actor }) => {
+    const { token } = await registerAndVerifyEmail(actor.ctx, actor.email);
+    const auth = { Authorization: `Bearer ${token}` };
+
+    const start = await actor.ctx.post('/totp/enroll/start', { headers: auth, data: {} });
+    expect(start.ok(), `enroll/start -> ${start.status()}`).toBeTruthy();
+    const { secret } = await start.json();
+    expect(secret, 'enroll/start returns a base32 secret').toBeTruthy();
+
+    const verify = await actor.ctx.post('/totp/enroll/verify', {
+      headers: auth,
+      data: { code: totp(secret) },
+    });
+    expect(verify.ok(), `enroll/verify -> ${verify.status()}`).toBeTruthy();
+
+    const status = await actor.ctx.get('/totp/status', { headers: auth });
+    expect((await status.json()).enabled, 'TOTP is enabled after enrollment').toBe(true);
+  });
+});

--- a/verify/harness/lib/env.ts
+++ b/verify/harness/lib/env.ts
@@ -7,6 +7,11 @@ export const ADAPTER_URL = process.env.SEAMLESS_ADAPTER_URL ?? 'http://localhost
 export const API_SERVICE_TOKEN =
   process.env.SEAMLESS_API_SERVICE_TOKEN ?? 'verify-dev-service-token';
 
+// Must match the API's SEAMLESS_BOOTSTRAP_SECRET so the harness can mint the
+// first admin invite (bootstrap-promotion flow).
+export const BOOTSTRAP_SECRET =
+  process.env.SEAMLESS_BOOTSTRAP_SECRET ?? 'verify-dev-bootstrap-secret';
+
 // Non-production seam: makes the API return OTP / magic-link tokens in the
 // response `delivery` object instead of sending real email/SMS.
 export const EXTERNAL_DELIVERY = {

--- a/verify/harness/lib/env.ts
+++ b/verify/harness/lib/env.ts
@@ -30,9 +30,11 @@ export function uniqueClientIp(): string {
   return `10.${(n >> 16) & 255}.${(n >> 8) & 255}.${n & 255}`;
 }
 
-// Valid-format US numbers in the 555-01xx fictional range.
+// Valid-format US numbers, seeded by runId so they don't collide across runs.
+const phoneSeed = Number(runId) || 1_000_000;
 let phoneCounter = 0;
 export function uniquePhone(): string {
   phoneCounter += 1;
-  return `+1${4155550100 + phoneCounter}`;
+  const subscriber = 2_000_000 + ((phoneSeed + phoneCounter) % 7_000_000);
+  return `+1415${subscriber}`;
 }

--- a/verify/harness/lib/env.ts
+++ b/verify/harness/lib/env.ts
@@ -29,3 +29,10 @@ export function uniqueClientIp(): string {
   const n = ipCounter;
   return `10.${(n >> 16) & 255}.${(n >> 8) & 255}.${n & 255}`;
 }
+
+// Valid-format US numbers in the 555-01xx fictional range.
+let phoneCounter = 0;
+export function uniquePhone(): string {
+  phoneCounter += 1;
+  return `+1${4155550100 + phoneCounter}`;
+}

--- a/verify/harness/lib/flows.ts
+++ b/verify/harness/lib/flows.ts
@@ -1,6 +1,6 @@
 import { APIRequestContext, expect } from '@playwright/test';
 
-import { EXTERNAL_DELIVERY } from './env';
+import { BOOTSTRAP_SECRET, EXTERNAL_DELIVERY } from './env';
 
 export interface SessionTokens {
   token: string; // signed access token
@@ -36,6 +36,41 @@ export async function registerWithPhone(
   const res = await ctx.post('/registration/register', {
     headers: EXTERNAL_DELIVERY,
     data: { email, phone },
+  });
+  expect(res.ok(), `register ${email} -> ${res.status()} ${await res.text()}`).toBeTruthy();
+  const body = await res.json();
+  expect(body.token, 'register returns an ephemeral token').toBeTruthy();
+  return body.token as string;
+}
+
+/**
+ * Mint the one-time bootstrap admin invite (returns the raw invite token via
+ * the external-delivery seam). Only succeeds before any admin exists — the API
+ * gates re-use with 410, so this assumes a fresh DB (what `seamless verify` runs).
+ */
+export async function createBootstrapInvite(
+  ctx: APIRequestContext,
+  email: string,
+): Promise<string> {
+  const res = await ctx.post('/internal/bootstrap/admin-invite', {
+    headers: { Authorization: `Bearer ${BOOTSTRAP_SECRET}`, ...EXTERNAL_DELIVERY },
+    data: { email },
+  });
+  expect(res.ok(), `bootstrap invite -> ${res.status()} ${await res.text()}`).toBeTruthy();
+  const token = (await res.json())?.data?.token;
+  expect(token, 'bootstrap invite returns a token via external delivery').toBeTruthy();
+  return String(token);
+}
+
+/** Register a user carrying a bootstrap invite token; returns the ephemeral token. */
+export async function registerWithBootstrapToken(
+  ctx: APIRequestContext,
+  email: string,
+  bootstrapToken: string,
+): Promise<string> {
+  const res = await ctx.post('/registration/register', {
+    headers: EXTERNAL_DELIVERY,
+    data: { email, bootstrapToken },
   });
   expect(res.ok(), `register ${email} -> ${res.status()} ${await res.text()}`).toBeTruthy();
   const body = await res.json();

--- a/verify/harness/lib/flows.ts
+++ b/verify/harness/lib/flows.ts
@@ -27,6 +27,40 @@ export async function registerEmail(ctx: APIRequestContext, email: string): Prom
   return body.token as string;
 }
 
+/** Register a new user with email + phone; returns the ephemeral (pre-auth) token. */
+export async function registerWithPhone(
+  ctx: APIRequestContext,
+  email: string,
+  phone: string,
+): Promise<string> {
+  const res = await ctx.post('/registration/register', {
+    headers: EXTERNAL_DELIVERY,
+    data: { email, phone },
+  });
+  expect(res.ok(), `register ${email} -> ${res.status()} ${await res.text()}`).toBeTruthy();
+  const body = await res.json();
+  expect(body.token, 'register returns an ephemeral token').toBeTruthy();
+  return body.token as string;
+}
+
+/** Generate a phone OTP and return the raw code via the external-delivery seam. */
+export async function requestPhoneOtp(ctx: APIRequestContext, ephemeral: string): Promise<string> {
+  const res = await ctx.get('/otp/generate-phone-otp', {
+    headers: { ...bearer(ephemeral), ...EXTERNAL_DELIVERY },
+  });
+  expect(res.ok(), `generate-phone-otp -> ${res.status()} ${await res.text()}`).toBeTruthy();
+  const code = (await res.json())?.delivery?.token;
+  expect(code, 'external delivery returns the phone OTP code').toBeTruthy();
+  return String(code);
+}
+
+export function verifyPhoneOtp(ctx: APIRequestContext, ephemeral: string, code: string) {
+  return ctx.post('/otp/verify-phone-otp', {
+    headers: bearer(ephemeral),
+    data: { verificationToken: code },
+  });
+}
+
 /** Generate an email OTP and return the raw code via the external-delivery seam. */
 export async function requestEmailOtp(ctx: APIRequestContext, ephemeral: string): Promise<string> {
   const res = await ctx.get('/otp/generate-email-otp', {

--- a/verify/harness/lib/totp.ts
+++ b/verify/harness/lib/totp.ts
@@ -1,0 +1,36 @@
+import { createHmac } from 'crypto';
+
+function base32Decode(input: string): Buffer {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  const clean = input.replace(/=+$/, '').toUpperCase().replace(/\s/g, '');
+  let bits = 0;
+  let value = 0;
+  const out: number[] = [];
+  for (const ch of clean) {
+    const idx = alphabet.indexOf(ch);
+    if (idx === -1) continue;
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      out.push((value >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+  return Buffer.from(out);
+}
+
+// RFC-6238 TOTP (SHA1, 6 digits, 30s) — matches the API's TOTP parameters.
+export function totp(secretBase32: string, atMs = Date.now(), period = 30, digits = 6): string {
+  const key = base32Decode(secretBase32);
+  const counter = Math.floor(atMs / 1000 / period);
+  const buf = Buffer.alloc(8);
+  buf.writeBigInt64BE(BigInt(counter));
+  const hmac = createHmac('sha1', key).update(buf).digest();
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  const bin =
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff);
+  return String(bin % 10 ** digits).padStart(digits, '0');
+}


### PR DESCRIPTION
Extends the `seamless verify` conformance harness to cover the remaining request-layer
auth flows. Full matrix is **15/15 green** on a clean DB (`down -v` + fresh `up`):

```
✓ api      adminBootstrap   invite → register → magic-link → admin role   (new)
✓ api      emailOtp         register → OTP → session  (+ wrong-code 401)
✓ api      phoneOtp         register+phone → OTP  (+ wrong-code 401)        (new)
✓ api      magicLink        request → poll(204) → verify → session  (+ invalid)
✓ api      sessionLifecycle refresh; sessions list + logout revoke
✓ api      jwks             publishes dev-main RSA signing key             (new)
✓ api      totp             enroll → verify computed code → status enabled (new)
✓ api      organizations    create → list → switch active                 (new)
✓ adapter  emailOtpLogin / magicLink / sessionLifecycle  (cookie path)
```

### New cases
- **admin bootstrap-promotion** — mints the one-time admin invite via the external-delivery
  seam, registers a user carrying the invite token, completes via magic-link, and asserts the
  issued session carries the `admin` role. Inherently single-use per DB (the API returns `410`
  once an admin exists) — relies on the `seamless verify` `down -v`.
- **phone-OTP** (register + wrong-code 401), **JWKS** (publishes the `dev-main` RSA key),
  **TOTP** (RFC-6238 enroll → verify a computed code → status enabled), **organizations**
  (create → list → switch).

### Fixes / robustness
- `uniquePhone()` now seeds from `runId` (mirrors `uniqueEmail`) so numbers don't collide
  across runs on a persistent DB.
- Adapter `sessionLifecycle` now logs in via magic-link (separate rate limiter) instead of a
  second email-OTP round-trip. The adapter funnels all upstream OTP through one client IP, so
  the three adapter specs were colliding on the API's per-IP OTP limiter (10/15min). This keeps
  the project's aggregate OTP traffic under the cap.

### Finding surfaced by the harness
Filed **fells-code/seamless-auth-server#41**: every `@seamless-auth/core` handler calls
`await up.json()` unconditionally, so a non-JSON upstream response (the API's plaintext `429`)
crashes the adapter process. A user hitting a rate limit mid-login can take down the adapter
server — fix belongs in the SDK.
