### PR TITLE
test(verify): M3 — passkey register + login (virtual authenticator)

### DIFF
--- a/verify/harness/lib/reactFlows.ts
+++ b/verify/harness/lib/reactFlows.ts
@@ -1,4 +1,4 @@
-import { expect, Page, request } from '@playwright/test';
+import { BrowserContext, expect, Page, request } from '@playwright/test';
 
 import { ADAPTER_URL } from './env';
 
@@ -29,10 +29,17 @@ export async function readCapturedCode(recipient: string, timeoutMs = 10_000): P
   }
 }
 
-/** Open the sign-in form (the SDK renders the register form by default). */
+/**
+ * Open the sign-in form. The SDK usually renders the register form by default, but
+ * lands directly on sign-in in some states (e.g. just after logout), so switch only
+ * when needed — and wait for the form to render first to avoid racing the SPA.
+ */
 export async function gotoSignIn(page: Page): Promise<void> {
   await page.goto('/login');
-  await page.getByRole('button', { name: /Sign in/i }).click();
+  await expect(page.getByRole('heading', { name: /Sign In|Create Account/ })).toBeVisible();
+  if (await page.getByRole('heading', { name: 'Create Account' }).isVisible()) {
+    await page.getByRole('button', { name: /Already have an account/i }).click();
+  }
   await expect(page.getByRole('heading', { name: 'Sign In' })).toBeVisible();
 }
 
@@ -42,6 +49,56 @@ export async function enterOtp(page: Page, code: string): Promise<void> {
   await expect(boxes).toHaveCount(code.length);
   await boxes.first().click();
   await page.keyboard.type(code);
+}
+
+/**
+ * Attach a CTAP2 platform virtual authenticator (Chrome DevTools Protocol) so
+ * WebAuthn ceremonies auto-succeed — this is what makes `isUVPAA()` true (so the
+ * SDK offers passkeys) and lets navigator.credentials.create/get resolve headless.
+ */
+export async function addVirtualAuthenticator(
+  context: BrowserContext,
+  page: Page,
+): Promise<void> {
+  const cdp = await context.newCDPSession(page);
+  await cdp.send('WebAuthn.enable');
+  await cdp.send('WebAuthn.addVirtualAuthenticator', {
+    options: {
+      protocol: 'ctap2',
+      transport: 'internal',
+      hasResidentKey: true,
+      hasUserVerification: true,
+      isUserVerified: true,
+      automaticPresenceSimulation: true,
+    },
+  });
+}
+
+/** Register a new user by email, then enroll a passkey (passkey support must be on). */
+export async function registerWithPasskey(page: Page, email: string): Promise<void> {
+  await page.goto('/login');
+  await expect(page.getByRole('heading', { name: 'Create Account' })).toBeVisible();
+  await page.locator('#email').fill(email);
+  await page.getByRole('button', { name: 'Register', exact: true }).click();
+
+  await expect(page.getByRole('heading', { name: 'Verify Your Email' })).toBeVisible();
+  await enterOtp(page, await readCapturedCode(email));
+  await page.getByRole('button', { name: /Verify & Continue/ }).click();
+
+  // Passkey support is detected, so registration continues to passkey enrollment.
+  await expect(
+    page.getByRole('heading', { name: /Secure Your Account with a Passkey/ }),
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Register Passkey' }).click();
+  await page.getByPlaceholder(/MacBook/).fill('Verify Device');
+  await page.getByRole('button', { name: 'Continue' }).click();
+}
+
+/** Sign in an existing user whose passkey is registered (the ceremony auto-runs). */
+export async function loginWithPasskey(page: Page, email: string): Promise<void> {
+  await gotoSignIn(page);
+  await page.locator('#identifier').fill(email);
+  await page.getByRole('button', { name: 'Login', exact: true }).click();
 }
 
 /** Sign in an existing verified user through the email one-time-code path. */

--- a/verify/harness/react/passkeyLogin.spec.ts
+++ b/verify/harness/react/passkeyLogin.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '../lib/fixtures';
+import {
+  addVirtualAuthenticator,
+  loginWithPasskey,
+  registerWithPasskey,
+} from '../lib/reactFlows';
+
+test.describe('passkey login (react, browser)', () => {
+  test('a registered passkey signs the user back in', async ({ page, context, actor }) => {
+    await addVirtualAuthenticator(context, page);
+
+    // Enroll a passkey, then sign out.
+    await registerWithPasskey(page, actor.email);
+    await expect(page.getByText('You are signed in')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Open account menu' }).click();
+    await page.getByRole('button', { name: 'Logout' }).click();
+    await expect(page.getByText('You are signed in')).toBeHidden();
+
+    // Sign in with only the passkey (identifier -> the ceremony runs automatically).
+    await loginWithPasskey(page, actor.email);
+    await expect(page.getByText('You are signed in')).toBeVisible();
+  });
+});

--- a/verify/harness/react/passkeyRegister.spec.ts
+++ b/verify/harness/react/passkeyRegister.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '../lib/fixtures';
+import { addVirtualAuthenticator, registerWithPasskey } from '../lib/reactFlows';
+
+test.describe('passkey registration (react, browser)', () => {
+  test('register, then enroll a passkey via a virtual authenticator -> signed in', async ({
+    page,
+    context,
+    actor,
+  }) => {
+    await addVirtualAuthenticator(context, page);
+
+    await registerWithPasskey(page, actor.email);
+    await expect(page.getByText('You are signed in')).toBeVisible();
+  });
+});


### PR DESCRIPTION
Adds **M3** of the `seamless verify` harness: passkey register + login in a real browser
via a CDP virtual authenticator. Full matrix is **22/22 green** end-to-end (`seamless verify`).

### Browser cases (react project)
- **passkey registration** — register by email → enroll a passkey → signed in.
- **passkey login** — enroll a passkey, log out, then sign back in with **only** the passkey
  (the WebAuthn ceremony runs automatically on sign-in).

### How
- Attach a CTAP2 **platform** virtual authenticator over the Chrome DevTools Protocol
  (`WebAuthn.addVirtualAuthenticator`, `isUserVerified` + `automaticPresenceSimulation`).
  This makes `isUserVerifyingPlatformAuthenticatorAvailable()` true (so the SDK offers
  passkeys) and lets `navigator.credentials.create/get` resolve headless.
- `gotoSignIn` is now tolerant of either starting auth-form mode (the form lands directly
  on sign-in in some post-logout states), waiting for render before switching.

### Scope note
Passkeys are browser/authenticator-native, so they're covered at the **react** layer (real
ceremony) rather than the request-context adapter layer — there's no browser there to run
WebAuthn. This also exercises the email-first registration → passkey-enrollment branch.

Next: M4 (OAuth via in-process mock OIDC).
