### PR TITLE
chore: pin templates to v0.2.3

### DIFF
--- a/.changeset/bump-templates-ref-v0.2.3.md
+++ b/.changeset/bump-templates-ref-v0.2.3.md
@@ -1,0 +1,5 @@
+---
+"seamless-cli": patch
+---
+
+Bump the pinned `seamless-templates` ref to `v0.2.3`, so `seamless init` scaffolds the templates that ship `@seamless-auth/react` `^0.4.0` (TOTP support) and `@seamless-auth/express` `^0.7.0`.

--- a/src/core/images.ts
+++ b/src/core/images.ts
@@ -13,4 +13,4 @@ export const SEAMLESS_AUTH_ADMIN_DASHBOARD_IMAGE = `ghcr.io/fells-code/seamless-
 // SEAMLESS_TEMPLATES_REF, or point at a local checkout with SEAMLESS_TEMPLATES_DIR.
 export const SEAMLESS_TEMPLATES_REPO = "fells-code/seamless-templates";
 
-export const SEAMLESS_TEMPLATES_REF = "v0.2.2";
+export const SEAMLESS_TEMPLATES_REF = "v0.2.3";


### PR DESCRIPTION
## What

Bump the pinned `seamless-templates` ref from `v0.2.2` to `v0.2.3` in [src/core/images.ts](src/core/images.ts).

## Why

`seamless-templates` `v0.2.3` bumped the bundled Seamless Auth SDK versions in the starter templates (`@seamless-auth/react` to `^0.4.0` for TOTP support, and `@seamless-auth/express` to `^0.7.0`, which pulls in `@seamless-auth/core` `0.7.0`). This is the second half of the documented two-step templates-ref dance: the templates release landed first, this pins the CLI to it so `seamless init` scaffolds the new SDK versions.

Conformance CI is unaffected: `verify-conformance.yml` checks out `seamless-templates` at its default branch (empty `templates-ref` input), so it already tracks the change on `main`.

## Verification

- `npm run build` passes; the compiled `dist/core/images.js` reflects `v0.2.3`.
- A changeset (`patch` to `seamless-cli`) is included.
