### PR TITLE
ci(verify): check out seamless-auth-server from its default branch

### DIFF
--- a/.github/workflows/verify-conformance.yml
+++ b/.github/workflows/verify-conformance.yml
@@ -52,9 +52,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: fells-code/seamless-auth-server
-          # The server's integration branch is `dev` (where fixes land and the beta
-          # publishes from); its `main` lags. Default to `dev` when no ref is passed.
-          ref: ${{ inputs.server-ref || 'dev' }}
+          ref: ${{ inputs.server-ref }}
           path: seamless-auth-server
 
       - name: Checkout seamless-auth-react

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,8 +137,8 @@ Modes and sibling repos:
 
 ## Known Maintenance Traps
 
-- **Sibling-repo branches**: the server's integration branch is `dev` (its `main` lags), so the verify
-  CI workflow defaults the server checkout to `dev`. The api, react SDK, and seamless-templates use `main`.
+- **Sibling-repo branches**: every sibling repo (api, server, react SDK, seamless-templates) is checked out
+  at its default branch (`main`) when no explicit `*-ref` is passed to the verify CI workflow.
 - **`--local` needs SDK dependencies**: it builds the server (pnpm) and the React SDK (npm) from source
   on the host, so those repos must have their dependencies installed first. CI installs them explicitly.
 - **OAuth mock networking**: the in-process mock OIDC is reached by the browser and harness via


### PR DESCRIPTION
## What

The `seamless-auth-server` repo no longer maintains a separate `dev` integration branch; `main` is now its single branch. This drops the `dev` default for the server checkout in the reusable conformance workflow so it resolves to the repo's default branch (`main`), consistent with every other sibling repo (api, react SDK, seamless-templates).

## Changes

- `.github/workflows/verify-conformance.yml`: `ref: ${{ inputs.server-ref || 'dev' }}` becomes `ref: ${{ inputs.server-ref }}`, and the now-inaccurate comment about `dev` is removed. An explicit `server-ref` input still overrides it.
- `AGENTS.md`: updated the "Sibling-repo branches" maintenance note to reflect that all siblings default to `main`.

## Why

With no `dev` branch on the server, the workflow would fail to check it out (or silently test the wrong ref). Defaulting to the default branch keeps conformance runs green and matches the other repos.

## Testing

- YAML validated (parses cleanly).
- No behavioral change to the local `seamless verify` command; this only affects the CI checkout ref. No changeset (CI/docs only, not a published-package change).
