### PR TITLE
feat(keychain): secure per-profile token storage in the OS keychain

### DIFF
--- a/.changeset/keychain-token-storage.md
+++ b/.changeset/keychain-token-storage.md
@@ -1,0 +1,12 @@
+---
+"seamless-cli": minor
+---
+
+Store session tokens in the OS keychain (macOS Keychain, Windows Credential
+Manager, Linux Secret Service) via `@napi-rs/keyring` instead of on disk. Tokens
+are scoped per profile (keyed by profile name and instance URL) so multiple
+instances never collide, and the refresh token, the durable secret, never
+touches config or logs. `seamless profile remove` now clears the profile's
+keychain entry. When no keychain is available (for example headless CI), the CLI
+reads a refresh token from `SEAMLESS_REFRESH_TOKEN` if set and otherwise fails
+with a clear, documented error rather than writing secrets to disk.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@clack/prompts": "^1.0.1",
+        "@napi-rs/keyring": "^1.3.0",
         "adm-zip": "^0.5.16",
         "kleur": "^4.1.5"
       },
@@ -909,6 +910,240 @@
       },
       "engines": {
         "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@napi-rs/keyring": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.3.0.tgz",
+      "integrity": "sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring-darwin-arm64": "1.3.0",
+        "@napi-rs/keyring-darwin-x64": "1.3.0",
+        "@napi-rs/keyring-freebsd-x64": "1.3.0",
+        "@napi-rs/keyring-linux-arm-gnueabihf": "1.3.0",
+        "@napi-rs/keyring-linux-arm64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-arm64-musl": "1.3.0",
+        "@napi-rs/keyring-linux-riscv64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-x64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-x64-musl": "1.3.0",
+        "@napi-rs/keyring-win32-arm64-msvc": "1.3.0",
+        "@napi-rs/keyring-win32-ia32-msvc": "1.3.0",
+        "@napi-rs/keyring-win32-x64-msvc": "1.3.0"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-freebsd-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.3.0.tgz",
+      "integrity": "sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.3.0.tgz",
+      "integrity": "sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.3.0.tgz",
+      "integrity": "sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.3.0.tgz",
+      "integrity": "sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.3.0.tgz",
+      "integrity": "sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-x64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.3.0.tgz",
+      "integrity": "sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   ],
   "dependencies": {
     "@clack/prompts": "^1.0.1",
+    "@napi-rs/keyring": "^1.3.0",
     "adm-zip": "^0.5.16",
     "kleur": "^4.1.5"
   },

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -11,6 +11,7 @@ import {
   upsertProfile,
   type IdentifierType,
 } from "../core/config.js";
+import { deleteTokens, KeychainUnavailableError } from "../core/keychain.js";
 
 export async function runProfile(args: string[]): Promise<void> {
   const sub = args[0];
@@ -27,7 +28,7 @@ export async function runProfile(args: string[]): Promise<void> {
       profileUse(rest);
       return;
     case "remove":
-      profileRemove(rest);
+      await profileRemove(rest);
       return;
     default:
       console.error(
@@ -145,18 +146,36 @@ function profileUse(rest: string[]): void {
   console.log(kleur.green(`Active profile set to "${name}".`));
 }
 
-function profileRemove(rest: string[]): void {
+async function profileRemove(rest: string[]): Promise<void> {
   const name = rest[0];
   if (!name) {
     console.error(kleur.red("Usage: seamless profile remove <name>"));
     process.exit(1);
   }
 
+  const profile = loadConfig().profiles[name];
+
   try {
     removeProfile(name);
   } catch (err) {
     console.error(kleur.red((err as Error).message));
     process.exit(1);
+  }
+
+  if (profile) {
+    try {
+      await deleteTokens(profile);
+    } catch (err) {
+      if (err instanceof KeychainUnavailableError) {
+        console.log(
+          kleur.dim("No keychain available; no stored tokens to clear."),
+        );
+      } else {
+        console.log(
+          kleur.yellow(`Could not clear stored tokens: ${(err as Error).message}`),
+        );
+      }
+    }
   }
 
   console.log(kleur.green(`Profile "${name}" removed.`));

--- a/src/core/keychain.test.ts
+++ b/src/core/keychain.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  accountKey,
+  deleteTokens,
+  getTokens,
+  redactToken,
+  saveTokens,
+  scrubTokens,
+  setBackendForTesting,
+  type KeychainBackend,
+  type TokenBundle,
+} from "./keychain.js";
+
+function fakeBackend(): KeychainBackend & { store: Map<string, string> } {
+  const store = new Map<string, string>();
+  return {
+    store,
+    get: (account) => store.get(account) ?? null,
+    set: (account, secret) => {
+      store.set(account, secret);
+    },
+    delete: (account) => store.delete(account),
+  };
+}
+
+const prod = { name: "prod", instanceUrl: "https://auth.example.com" };
+const bundle: TokenBundle = {
+  accessToken: "access-abc",
+  refreshToken: "refresh-xyz",
+  accessTokenExpiresAt: 1000,
+  refreshTokenExpiresAt: 2000,
+};
+
+let backend: ReturnType<typeof fakeBackend>;
+
+beforeEach(() => {
+  backend = fakeBackend();
+  setBackendForTesting(backend);
+  delete process.env.SEAMLESS_REFRESH_TOKEN;
+});
+
+afterEach(() => {
+  setBackendForTesting(null);
+  delete process.env.SEAMLESS_REFRESH_TOKEN;
+});
+
+describe("accountKey", () => {
+  it("scopes by profile name and instance URL", () => {
+    expect(accountKey(prod)).toBe("prod::https://auth.example.com");
+    expect(accountKey({ name: "prod", instanceUrl: "https://other.example.com" })).not.toBe(
+      accountKey(prod),
+    );
+  });
+});
+
+describe("saveTokens / getTokens", () => {
+  it("round-trips a token bundle", async () => {
+    await saveTokens(prod, bundle);
+    expect(await getTokens(prod)).toEqual(bundle);
+  });
+
+  it("keeps tokens for same-named profiles on different instances separate", async () => {
+    const staging = { name: "prod", instanceUrl: "https://staging.example.com" };
+    await saveTokens(prod, bundle);
+    await saveTokens(staging, { accessToken: "a2", refreshToken: "r2" });
+
+    expect((await getTokens(prod))?.refreshToken).toBe("refresh-xyz");
+    expect((await getTokens(staging))?.refreshToken).toBe("r2");
+    expect(backend.store.size).toBe(2);
+  });
+
+  it("returns null when nothing is stored", async () => {
+    expect(await getTokens(prod)).toBeNull();
+  });
+
+  it("returns null on corrupt stored data", async () => {
+    backend.set(accountKey(prod), "{ not json");
+    expect(await getTokens(prod)).toBeNull();
+  });
+});
+
+describe("SEAMLESS_REFRESH_TOKEN fallback", () => {
+  it("returns the env refresh token without touching the keychain", async () => {
+    process.env.SEAMLESS_REFRESH_TOKEN = "ci-refresh";
+    setBackendForTesting({
+      get: () => {
+        throw new Error("keychain should not be read when env is set");
+      },
+      set: () => {},
+      delete: () => false,
+    });
+
+    expect(await getTokens(prod)).toEqual({
+      accessToken: "",
+      refreshToken: "ci-refresh",
+    });
+  });
+});
+
+describe("deleteTokens", () => {
+  it("clears a profile's entry", async () => {
+    await saveTokens(prod, bundle);
+    expect(await deleteTokens(prod)).toBe(true);
+    expect(await getTokens(prod)).toBeNull();
+  });
+
+  it("reports false when there was nothing to delete", async () => {
+    expect(await deleteTokens(prod)).toBe(false);
+  });
+});
+
+describe("redaction", () => {
+  it("redactToken never returns the secret", () => {
+    expect(redactToken("super-secret-refresh-token")).toBe("[redacted]");
+    expect(redactToken("")).toBe("(none)");
+    expect(redactToken(undefined)).toBe("(none)");
+  });
+
+  it("scrubTokens masks token-like fields recursively", () => {
+    const scrubbed = scrubTokens({
+      email: "dev@example.com",
+      token: "access-abc",
+      nested: { refreshToken: "refresh-xyz", other: 1 },
+      list: [{ Authorization: "Bearer x" }],
+    });
+
+    expect(scrubbed).toEqual({
+      email: "dev@example.com",
+      token: "[redacted]",
+      nested: { refreshToken: "[redacted]", other: 1 },
+      list: [{ Authorization: "[redacted]" }],
+    });
+  });
+});

--- a/src/core/keychain.ts
+++ b/src/core/keychain.ts
@@ -1,0 +1,144 @@
+import type { Profile } from "./config.js";
+
+const SERVICE = "seamless-cli";
+
+export interface TokenBundle {
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpiresAt?: number;
+  refreshTokenExpiresAt?: number;
+}
+
+export class KeychainUnavailableError extends Error {
+  constructor(cause?: unknown) {
+    super(
+      "No OS keychain is available. Set SEAMLESS_REFRESH_TOKEN to authenticate in a headless environment, or run on a machine with a keychain (macOS Keychain, Windows Credential Manager, or Linux Secret Service).",
+    );
+    this.name = "KeychainUnavailableError";
+    if (cause !== undefined) this.cause = cause;
+  }
+}
+
+export interface KeychainBackend {
+  get(account: string): string | null;
+  set(account: string, secret: string): void;
+  delete(account: string): boolean;
+}
+
+export function accountKey(
+  profile: Pick<Profile, "name" | "instanceUrl">,
+): string {
+  return `${profile.name}::${profile.instanceUrl}`;
+}
+
+function isNoEntry(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /no (matching )?entry/i.test(message) || /not found/i.test(message);
+}
+
+let backend: KeychainBackend | null = null;
+
+async function loadBackend(): Promise<KeychainBackend> {
+  if (backend) return backend;
+
+  let Entry: typeof import("@napi-rs/keyring").Entry;
+  try {
+    ({ Entry } = await import("@napi-rs/keyring"));
+  } catch (err) {
+    throw new KeychainUnavailableError(err);
+  }
+
+  backend = {
+    get(account) {
+      try {
+        return new Entry(SERVICE, account).getPassword();
+      } catch (err) {
+        if (isNoEntry(err)) return null;
+        throw new KeychainUnavailableError(err);
+      }
+    },
+    set(account, secret) {
+      try {
+        new Entry(SERVICE, account).setPassword(secret);
+      } catch (err) {
+        throw new KeychainUnavailableError(err);
+      }
+    },
+    delete(account) {
+      try {
+        return new Entry(SERVICE, account).deletePassword();
+      } catch (err) {
+        if (isNoEntry(err)) return false;
+        throw new KeychainUnavailableError(err);
+      }
+    },
+  };
+
+  return backend;
+}
+
+export function setBackendForTesting(fake: KeychainBackend | null): void {
+  backend = fake;
+}
+
+export async function saveTokens(
+  profile: Pick<Profile, "name" | "instanceUrl">,
+  bundle: TokenBundle,
+): Promise<void> {
+  const b = await loadBackend();
+  b.set(accountKey(profile), JSON.stringify(bundle));
+}
+
+export async function getTokens(
+  profile: Pick<Profile, "name" | "instanceUrl">,
+): Promise<TokenBundle | null> {
+  const envRefresh = process.env.SEAMLESS_REFRESH_TOKEN?.trim();
+  if (envRefresh) {
+    return { accessToken: "", refreshToken: envRefresh };
+  }
+
+  const b = await loadBackend();
+  const raw = b.get(accountKey(profile));
+  if (!raw) return null;
+
+  try {
+    return JSON.parse(raw) as TokenBundle;
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteTokens(
+  profile: Pick<Profile, "name" | "instanceUrl">,
+): Promise<boolean> {
+  const b = await loadBackend();
+  return b.delete(accountKey(profile));
+}
+
+export function redactToken(value?: string | null): string {
+  return value ? "[redacted]" : "(none)";
+}
+
+const TOKEN_KEYS = new Set([
+  "token",
+  "accesstoken",
+  "refreshtoken",
+  "verificationtoken",
+  "authorization",
+]);
+
+export function scrubTokens<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => scrubTokens(item)) as unknown as T;
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      out[key] = TOKEN_KEYS.has(key.toLowerCase())
+        ? redactToken(typeof val === "string" ? val : String(val))
+        : scrubTokens(val);
+    }
+    return out as T;
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

Second issue in the CLI auth epic (#38). Stores session tokens in the OS keychain instead of on disk, so the refresh token (the durable secret) never lands in cleartext.

- `src/core/keychain.ts`: adapter over [`@napi-rs/keyring`](https://www.npmjs.com/package/@napi-rs/keyring) with prebuilt backends for macOS Keychain, Windows Credential Manager, and Linux Secret Service.
- One entry per profile, service `seamless-cli`, account key `${name}::${instanceUrl}`, so same-named profiles on different instances never collide.
- Payload is a JSON bundle: access token, refresh token, and expiries.
- The native module is lazy-loaded behind a swappable `KeychainBackend` interface, so the logic is unit-testable without touching the real OS keychain in CI.

## Headless / CI fallback (opt-in, documented)

When no keychain is available, `getTokens` reads the refresh token from `SEAMLESS_REFRESH_TOKEN` if set; otherwise the adapter throws a clear `KeychainUnavailableError`. No plaintext is ever written to disk.

## Redaction

Adds `redactToken` and `scrubTokens` helpers so tokens are masked in logs and error output. The transparent-refresh HTTP client (#41) will use these on request/response logging.

## Wire-up

`seamless profile remove` now clears the profile's keychain entry (acceptance criterion), degrading gracefully with a clear message when no keychain is present.

## Tests / verification

- `npm run build` (tsc strict): passing.
- `npm test` (vitest): 28 passing (10 new keychain tests: scoping, round-trip, env fallback, deletion, redaction).
- Smoke-tested the real macOS Keychain backend end to end: env fallback, save/get round-trip, delete returns true, get returns null after delete.

## Acceptance criteria

- [x] The refresh token is retrievable only through the keychain (or the explicit env fallback), never written to config or logs.
- [x] Tokens are scoped per profile so multiple instances do not collide.
- [x] Removing a profile clears its keychain entries.

Closes #40