### PR TITLE
feat(http): authenticated client with transparent refresh

### DIFF
--- a/.changeset/authenticated-http-client.md
+++ b/.changeset/authenticated-http-client.md
@@ -1,0 +1,11 @@
+---
+"seamless-cli": minor
+---
+
+Add an authenticated HTTP client that targets the active profile's instance,
+attaches the Bearer access token, and transparently refreshes on expiry. On a
+401 it calls `POST /refresh` with the opaque refresh token, persists the rotated
+pair, and retries the original request once. A rotated or reused refresh token
+clears the local session and raises a clear re-login prompt instead of a stack
+trace. Non-JSON and empty response bodies are parsed defensively, and rate-limit
+(429) responses are surfaced without triggering a refresh.

--- a/src/core/authClient.test.ts
+++ b/src/core/authClient.test.ts
@@ -1,0 +1,229 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { upsertProfile } from "./config.js";
+import { isRateLimited } from "./http.js";
+import {
+  getTokens,
+  saveTokens,
+  setBackendForTesting,
+  type KeychainBackend,
+} from "./keychain.js";
+import {
+  createAuthClient,
+  ReauthRequiredError,
+  tokensFromAuthResponse,
+} from "./authClient.js";
+
+function fakeBackend(): KeychainBackend {
+  const store = new Map<string, string>();
+  return {
+    get: (account) => store.get(account) ?? null,
+    set: (account, secret) => {
+      store.set(account, secret);
+    },
+    delete: (account) => store.delete(account),
+  };
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+interface Call {
+  url: string;
+  init: RequestInit;
+}
+
+function mockFetch(makers: Array<() => Response>): Call[] {
+  const calls: Call[] = [];
+  let i = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, init: RequestInit = {}) => {
+      calls.push({ url, init });
+      const make = makers[Math.min(i, makers.length - 1)];
+      i++;
+      return make();
+    }),
+  );
+  return calls;
+}
+
+function authHeader(call: Call): string | undefined {
+  return (call.init.headers as Record<string, string> | undefined)
+    ?.Authorization;
+}
+
+const profile = { name: "default", instanceUrl: "https://auth.example.com" };
+let configHome: string;
+
+beforeEach(async () => {
+  configHome = fs.mkdtempSync(path.join(os.tmpdir(), "seamless-http-"));
+  process.env.XDG_CONFIG_HOME = configHome;
+  delete process.env.SEAMLESS_REFRESH_TOKEN;
+  setBackendForTesting(fakeBackend());
+  upsertProfile({ name: "default", instanceUrl: "https://auth.example.com" });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  setBackendForTesting(null);
+  fs.rmSync(configHome, { recursive: true, force: true });
+  delete process.env.XDG_CONFIG_HOME;
+  delete process.env.SEAMLESS_REFRESH_TOKEN;
+});
+
+describe("createAuthClient", () => {
+  it("throws a reauth error when there is no session", async () => {
+    await expect(createAuthClient()).rejects.toBeInstanceOf(ReauthRequiredError);
+  });
+});
+
+describe("transparent refresh", () => {
+  it("refreshes on 401, stores the rotated pair, and retries once", async () => {
+    await saveTokens(profile, {
+      accessToken: "old-access",
+      refreshToken: "old-refresh",
+    });
+
+    const calls = mockFetch([
+      () => new Response(null, { status: 401 }),
+      () =>
+        json({
+          token: "new-access",
+          refreshToken: "new-refresh",
+          ttl: 900,
+          refreshTtl: 86400,
+        }),
+      () => json({ sub: "user-1" }),
+    ]);
+
+    const client = await createAuthClient();
+    const res = await client.get<{ sub: string }>("/whoami");
+
+    expect(res.ok).toBe(true);
+    expect(res.data?.sub).toBe("user-1");
+    expect(calls).toHaveLength(3);
+
+    expect(authHeader(calls[0])).toBe("Bearer old-access");
+    expect(calls[1].url).toBe("https://auth.example.com/refresh");
+    expect(authHeader(calls[1])).toBe("Bearer old-refresh");
+    expect(authHeader(calls[2])).toBe("Bearer new-access");
+
+    const stored = await getTokens(profile);
+    expect(stored?.refreshToken).toBe("new-refresh");
+    expect(stored?.accessTokenExpiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it("re-sends the request body on the retried call", async () => {
+    await saveTokens(profile, {
+      accessToken: "old-access",
+      refreshToken: "old-refresh",
+    });
+
+    const calls = mockFetch([
+      () => new Response(null, { status: 401 }),
+      () => json({ token: "new-access", refreshToken: "new-refresh" }),
+      () => json({ ok: true }),
+    ]);
+
+    const client = await createAuthClient();
+    await client.post("/things", { name: "widget" });
+
+    expect(calls[2].init.body).toBe(JSON.stringify({ name: "widget" }));
+    expect(authHeader(calls[2])).toBe("Bearer new-access");
+  });
+
+  it("clears the session and demands re-login when refresh is rejected", async () => {
+    await saveTokens(profile, {
+      accessToken: "old-access",
+      refreshToken: "reused-refresh",
+    });
+
+    mockFetch([
+      () => new Response(null, { status: 401 }),
+      () => json({ error: "token reuse detected" }, 401),
+    ]);
+
+    const client = await createAuthClient();
+    await expect(client.get("/whoami")).rejects.toBeInstanceOf(
+      ReauthRequiredError,
+    );
+
+    expect(await getTokens(profile)).toBeNull();
+  });
+});
+
+describe("error and edge responses", () => {
+  beforeEach(async () => {
+    await saveTokens(profile, {
+      accessToken: "access",
+      refreshToken: "refresh",
+    });
+  });
+
+  it("surfaces 429 without attempting a refresh", async () => {
+    const calls = mockFetch([() => json({ error: "rate limited" }, 429)]);
+
+    const client = await createAuthClient();
+    const res = await client.get("/otp/generate-login-email-otp");
+
+    expect(res.status).toBe(429);
+    expect(isRateLimited(res)).toBe(true);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("does not crash on an HTML body", async () => {
+    mockFetch([
+      () =>
+        new Response("<html><body>502 Bad Gateway</body></html>", {
+          status: 502,
+          headers: { "content-type": "text/html" },
+        }),
+    ]);
+
+    const client = await createAuthClient();
+    const res = await client.get("/whoami");
+
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(502);
+    expect(res.data).toBeNull();
+  });
+
+  it("does not crash on an empty body", async () => {
+    mockFetch([() => new Response(null, { status: 204 })]);
+
+    const client = await createAuthClient();
+    const res = await client.get("/whoami");
+
+    expect(res.ok).toBe(true);
+    expect(res.data).toBeNull();
+  });
+});
+
+describe("tokensFromAuthResponse", () => {
+  it("maps the contract fields and computes expiries", () => {
+    const before = Date.now();
+    const bundle = tokensFromAuthResponse({
+      token: "a",
+      refreshToken: "r",
+      ttl: 300,
+      refreshTtl: 3600,
+    });
+
+    expect(bundle?.accessToken).toBe("a");
+    expect(bundle?.refreshToken).toBe("r");
+    expect(bundle?.accessTokenExpiresAt).toBeGreaterThanOrEqual(before + 300 * 1000);
+    expect(bundle?.refreshTokenExpiresAt).toBeGreaterThanOrEqual(before + 3600 * 1000);
+  });
+
+  it("returns null when required fields are missing", () => {
+    expect(tokensFromAuthResponse({ token: "a" })).toBeNull();
+    expect(tokensFromAuthResponse(null)).toBeNull();
+  });
+});

--- a/src/core/authClient.ts
+++ b/src/core/authClient.ts
@@ -1,0 +1,162 @@
+import { getActiveProfile, type Profile } from "./config.js";
+import {
+  deleteTokens,
+  getTokens,
+  KeychainUnavailableError,
+  saveTokens,
+  type TokenBundle,
+} from "./keychain.js";
+import { apiRequest, joinUrl, type ApiResponse } from "./http.js";
+
+export class ReauthRequiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReauthRequiredError";
+  }
+}
+
+export interface AuthClient {
+  profile: Profile;
+  request<T = unknown>(path: string, init?: RequestInit): Promise<ApiResponse<T>>;
+  get<T = unknown>(path: string, init?: RequestInit): Promise<ApiResponse<T>>;
+  post<T = unknown>(
+    path: string,
+    body?: unknown,
+    init?: RequestInit,
+  ): Promise<ApiResponse<T>>;
+}
+
+export function tokensFromAuthResponse(
+  data: Record<string, unknown> | null,
+): TokenBundle | null {
+  if (!data) return null;
+
+  const accessToken = typeof data.token === "string" ? data.token : undefined;
+  const refreshToken =
+    typeof data.refreshToken === "string" ? data.refreshToken : undefined;
+  if (!accessToken || !refreshToken) return null;
+
+  const now = Date.now();
+  const ttl = typeof data.ttl === "number" ? data.ttl : undefined;
+  const refreshTtl =
+    typeof data.refreshTtl === "number" ? data.refreshTtl : undefined;
+
+  return {
+    accessToken,
+    refreshToken,
+    accessTokenExpiresAt: ttl !== undefined ? now + ttl * 1000 : undefined,
+    refreshTokenExpiresAt:
+      refreshTtl !== undefined ? now + refreshTtl * 1000 : undefined,
+  };
+}
+
+export async function createAuthClient(
+  opts: { profileFlag?: string } = {},
+): Promise<AuthClient> {
+  const profile = getActiveProfile(opts);
+  if (!profile) {
+    throw new ReauthRequiredError(
+      "No active profile is configured. Add one with: seamless profile add <name> --instance-url <url>, then run seamless login.",
+    );
+  }
+
+  let tokens = await getTokens(profile);
+  if (!tokens || !tokens.refreshToken) {
+    throw new ReauthRequiredError(
+      `No session for profile "${profile.name}". Run: seamless login.`,
+    );
+  }
+  const session = tokens;
+
+  const persist = async (next: TokenBundle): Promise<void> => {
+    session.accessToken = next.accessToken;
+    session.refreshToken = next.refreshToken;
+    session.accessTokenExpiresAt = next.accessTokenExpiresAt;
+    session.refreshTokenExpiresAt = next.refreshTokenExpiresAt;
+    try {
+      await saveTokens(profile, next);
+    } catch (err) {
+      if (!(err instanceof KeychainUnavailableError)) throw err;
+    }
+  };
+
+  const clearSession = async (): Promise<void> => {
+    try {
+      await deleteTokens(profile);
+    } catch (err) {
+      if (!(err instanceof KeychainUnavailableError)) throw err;
+    }
+  };
+
+  const refresh = async (): Promise<void> => {
+    const res = await apiRequest<Record<string, unknown>>(
+      joinUrl(profile.instanceUrl, "/refresh"),
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${session.refreshToken}` },
+      },
+    );
+
+    if (!res.ok) {
+      await clearSession();
+      throw new ReauthRequiredError(
+        `Your session for "${profile.name}" has expired or was revoked. Run: seamless login.`,
+      );
+    }
+
+    const next = tokensFromAuthResponse(res.data);
+    if (!next) {
+      await clearSession();
+      throw new ReauthRequiredError(
+        `Received an unexpected refresh response from ${profile.instanceUrl}. Run: seamless login.`,
+      );
+    }
+
+    await persist(next);
+  };
+
+  const authedFetch = async <T>(
+    path: string,
+    init: RequestInit = {},
+  ): Promise<ApiResponse<T>> => {
+    const build = (): RequestInit => ({
+      ...init,
+      headers: {
+        ...(init.headers as Record<string, string> | undefined),
+        Authorization: `Bearer ${session.accessToken}`,
+      },
+    });
+
+    const url = joinUrl(profile.instanceUrl, path);
+    let res = await apiRequest<T>(url, build());
+
+    if (res.status === 401 && session.refreshToken) {
+      await refresh();
+      res = await apiRequest<T>(url, build());
+    }
+
+    return res;
+  };
+
+  return {
+    profile,
+    request: authedFetch,
+    get: (path, init = {}) => authedFetch(path, { ...init, method: "GET" }),
+    post: (path, body, init = {}) => {
+      const headers: Record<string, string> = {
+        ...(init.headers as Record<string, string> | undefined),
+      };
+      let bodyInit = init.body;
+      if (body !== undefined) {
+        headers["Content-Type"] = "application/json";
+        bodyInit = JSON.stringify(body);
+      }
+      return authedFetch(path, {
+        ...init,
+        method: "POST",
+        headers,
+        body: bodyInit,
+      });
+    },
+  };
+}

--- a/src/core/http.ts
+++ b/src/core/http.ts
@@ -1,0 +1,48 @@
+export interface ApiResponse<T = unknown> {
+  ok: boolean;
+  status: number;
+  data: T | null;
+  headers: Headers;
+}
+
+export function joinUrl(base: string, path: string): string {
+  if (/^https?:\/\//i.test(path)) return path;
+  return `${base}${path.startsWith("/") ? "" : "/"}${path}`;
+}
+
+export async function safeJson<T = unknown>(res: Response): Promise<T | null> {
+  const text = await res.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function apiRequest<T = unknown>(
+  url: string,
+  init: RequestInit = {},
+): Promise<ApiResponse<T>> {
+  const res = await fetch(url, init);
+  const data = await safeJson<T>(res);
+  return { ok: res.ok, status: res.status, data, headers: res.headers };
+}
+
+export function isRateLimited(res: Pick<ApiResponse, "status">): boolean {
+  return res.status === 429;
+}
+
+export function jsonBody(
+  method: string,
+  body?: unknown,
+  headers: Record<string, string> = {},
+): RequestInit {
+  const init: RequestInit = { method, headers: { ...headers } };
+  if (body !== undefined) {
+    (init.headers as Record<string, string>)["Content-Type"] =
+      "application/json";
+    init.body = JSON.stringify(body);
+  }
+  return init;
+}


### PR DESCRIPTION
## Summary

Third issue in the CLI auth epic (#38). A shared, authenticated fetch wrapper that composes the config store (#39) and keychain (#40): it targets the active profile's instance, attaches the Bearer access token, and refreshes transparently on expiry.

- `src/core/http.ts`: low-level helpers, `joinUrl`, a guarded `safeJson` (reads text then parses, so HTML or empty bodies never throw), `apiRequest` returning a typed `ApiResponse`, plus `isRateLimited` and `jsonBody`. Split out so `seamless login` (#42) can reuse them for the ephemeral-token flow.
- `src/core/authClient.ts`: `createAuthClient({ profileFlag })` resolving the active profile and stored tokens, with `get` / `post` / `request`.

## Transparent refresh

On a `401`, the client calls `POST /refresh` with the opaque refresh token, persists the rotated pair (contract rotates both tokens on every refresh), and retries the original request once with the new access token. Request bodies are re-sent on the retry.

## Failure handling

- A rejected refresh (rotated or reused token, the reuse-revokes-the-chain case) clears the local session and raises `ReauthRequiredError` so commands can print a clean "run seamless login" message instead of a stack trace.
- Rate-limit (429) responses are surfaced as-is and never trigger a refresh, so the CLI does not retry into the per-IP OTP limiter.
- Non-JSON and empty bodies parse to `null` rather than throwing (guards against the non-JSON upstream crash class noted in seamless-auth-server#41).

The keychain env fallback (`SEAMLESS_REFRESH_TOKEN`) composes here: with an empty stored access token the first call 401s, refreshes off the env token, and proceeds. Keychain-unavailable persistence failures are tolerated in that mode so a single invocation still works headless.

## Tests / verification

- `npm run build` (tsc strict): passing.
- `npm test` (vitest): 37 passing (9 new, driven by a stubbed `fetch`): refresh-and-retry with rotated tokens stored, body re-send, reused-token re-login with session cleared, 429 surfaced without refresh, and HTML / empty bodies handled.

No CLI command consumes the client yet (login is #42, whoami #43), so the mocked-transport tests are the exercise surface for this issue.

## Acceptance criteria

- [x] A call with an expired access token succeeds via one transparent refresh.
- [x] A rotated or reused refresh token results in a clean re-login prompt, not a stack trace.
- [x] Rate-limit (429) responses and HTML or empty bodies are handled gracefully.

Closes #41