### PR TITLE
feat(login): seamless login with the email OTP flow

### DIFF
--- a/.changeset/login-email-otp.md
+++ b/.changeset/login-email-otp.md
@@ -1,0 +1,15 @@
+---
+"seamless-cli": minor
+---
+
+Add `seamless login`, an interactive email OTP login for the active profile's
+Seamless Auth instance. It calls `POST /login` (honoring the instance's returned
+`loginMethods`), triggers the code with `GET /otp/generate-login-email-otp`,
+prompts for the code you paste from your inbox, and verifies it with `POST
+/otp/verify-login-email-otp`. On success it stores the session in the OS keychain
+and records the identity (sub, email, identifier type) on the profile. The
+command caps local code retries so it does not trip the per-IP OTP limiter,
+surfaces a 429 clearly, refreshes the code automatically if the 5 minute
+ephemeral window lapses, and reports unreachable instances without a stack trace.
+Accepts the identifier positionally or with `--identifier`, and targets a
+specific profile with `--profile`.

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -15,6 +15,7 @@ USAGE
   seamless bootstrap-admin [email]
   seamless verify [--api-only] [--filter=<flow>] [--keep-up]
   seamless profile <list|add|use|remove>
+  seamless login [identifier] [--identifier <email>] [--profile <name>]
   seamless --help
   seamless --version
 
@@ -55,6 +56,15 @@ COMMANDS
 
     The active profile can also be chosen per command with --profile <name> or
     the SEAMLESS_PROFILE environment variable.
+
+  login [identifier]
+    Log in to the active profile's Seamless Auth instance using email OTP.
+    Prompts for the identifier (or pass it positionally or with --identifier)
+    and the code sent to your inbox, then stores the session in the OS keychain.
+
+    --profile <name>
+      • Log in against a specific profile instead of the active one
+      • Also selectable with the SEAMLESS_PROFILE environment variable
 
   check
     Validate project setup, Docker, and running services

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,0 +1,106 @@
+import { intro, outro, text, isCancel, cancel } from "@clack/prompts";
+import kleur from "kleur";
+import { extractFlag } from "../core/args.js";
+import { getActiveProfile, upsertProfile, type Profile } from "../core/config.js";
+import { KeychainUnavailableError, saveTokens } from "../core/keychain.js";
+import { completeLogin, LoginError, type LoginResult } from "../core/loginFlow.js";
+
+export async function runLogin(args: string[]): Promise<void> {
+  const profileFlag = extractFlag(args, "profile");
+  const idFlag = extractFlag(profileFlag.rest, "identifier");
+
+  const profile = getActiveProfile({ profileFlag: profileFlag.value });
+  if (!profile) {
+    console.error(kleur.red("No active profile is configured."));
+    console.log(
+      "Add one with: " +
+        kleur.cyan("seamless profile add <name> --instance-url <url>"),
+    );
+    process.exit(1);
+  }
+
+  intro(`Log in to ${kleur.bold(profile.name)} (${profile.instanceUrl})`);
+
+  let identifier = (idFlag.value ?? idFlag.rest[0])?.trim();
+  if (!identifier) {
+    const answer = await text({
+      message: "Email or phone",
+      placeholder: profile.email ?? "you@example.com",
+      initialValue: profile.email ?? "",
+      validate: (value) =>
+        value && value.trim() ? undefined : "An identifier is required",
+    });
+    if (isCancel(answer)) {
+      cancel("Cancelled.");
+      return;
+    }
+    identifier = (answer as string).trim();
+  }
+
+  try {
+    const result = await completeLogin({
+      instanceUrl: profile.instanceUrl,
+      identifier,
+      getCode: async ({ resent }) => {
+        const answer = await text({
+          message: resent ? "Enter the new code" : "Enter the code we sent you",
+          placeholder: "123456",
+          validate: (value) =>
+            /^\d{4,8}$/.test((value ?? "").trim())
+              ? undefined
+              : "Enter the numeric code from the message",
+        });
+        if (isCancel(answer)) return null;
+        return (answer as string).trim();
+      },
+      notify: (event) => {
+        switch (event.type) {
+          case "code_sent":
+            console.log(kleur.dim(`A code was sent to ${identifier}.`));
+            break;
+          case "code_resent":
+            console.log(
+              kleur.dim("Your previous code expired, so we sent a new one."),
+            );
+            break;
+          case "incorrect":
+            console.log(
+              kleur.yellow(
+                `That code was not accepted. ${event.attemptsLeft} attempt${
+                  event.attemptsLeft === 1 ? "" : "s"
+                } left.`,
+              ),
+            );
+            break;
+        }
+      },
+    });
+
+    if (!result) {
+      cancel("Cancelled.");
+      return;
+    }
+
+    await persistSession(profile, result);
+    outro(kleur.green(`Logged in as ${result.identity.email ?? identifier}.`));
+  } catch (err) {
+    if (err instanceof LoginError || err instanceof KeychainUnavailableError) {
+      outro(kleur.red(err.message));
+      process.exit(1);
+    }
+    throw err;
+  }
+}
+
+async function persistSession(
+  profile: Profile,
+  result: LoginResult,
+): Promise<void> {
+  await saveTokens(profile, result.tokens);
+  upsertProfile({
+    ...profile,
+    sub: result.identity.sub ?? profile.sub,
+    email: result.identity.email ?? profile.email,
+    identifierType: result.identity.identifierType,
+  });
+}

--- a/src/core/loginFlow.test.ts
+++ b/src/core/loginFlow.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { completeLogin, LoginError } from "./loginFlow.js";
+
+interface Call {
+  url: string;
+  init: RequestInit;
+}
+
+type Responder = () => Response;
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function mockRouter(routes: Record<string, Responder[]>): Call[] {
+  const calls: Call[] = [];
+  const queues = new Map<string, Responder[]>(Object.entries(routes));
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, init: RequestInit = {}) => {
+      calls.push({ url, init });
+      const key = Object.keys(routes).find((path) => url.endsWith(path));
+      if (!key) throw new Error(`No route for ${url}`);
+      const queue = queues.get(key)!;
+      const responder = queue.length > 1 ? queue.shift()! : queue[0];
+      return responder();
+    }),
+  );
+
+  return calls;
+}
+
+function authHeader(call: Call): string | undefined {
+  return (call.init.headers as Record<string, string> | undefined)
+    ?.Authorization;
+}
+
+const INSTANCE = "https://auth.example.com";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("completeLogin", () => {
+  it("runs the email OTP flow end to end", async () => {
+    const calls = mockRouter({
+      "/login": [
+        () =>
+          json({
+            token: "ephemeral-1",
+            sub: "user-1",
+            identifierType: "email",
+            loginMethods: ["email_otp"],
+          }),
+      ],
+      "/otp/generate-login-email-otp": [() => json({ message: "sent" })],
+      "/otp/verify-login-email-otp": [
+        () =>
+          json({
+            token: "access-1",
+            refreshToken: "refresh-1",
+            ttl: 900,
+            refreshTtl: 86400,
+            sub: "user-1",
+            email: "dev@example.com",
+          }),
+      ],
+    });
+
+    const result = await completeLogin({
+      instanceUrl: INSTANCE,
+      identifier: "dev@example.com",
+      getCode: async () => "123456",
+    });
+
+    expect(result?.tokens.accessToken).toBe("access-1");
+    expect(result?.tokens.refreshToken).toBe("refresh-1");
+    expect(result?.identity).toEqual({
+      sub: "user-1",
+      email: "dev@example.com",
+      identifierType: "email",
+    });
+
+    const verify = calls.find((c) => c.url.endsWith("/otp/verify-login-email-otp"))!;
+    expect(authHeader(verify)).toBe("Bearer ephemeral-1");
+    expect(verify.init.body).toBe(JSON.stringify({ verificationToken: "123456" }));
+  });
+
+  it("retries a rejected code, then succeeds", async () => {
+    mockRouter({
+      "/login": [
+        () => json({ token: "e1", identifierType: "email", loginMethods: ["email_otp"] }),
+      ],
+      "/otp/generate-login-email-otp": [() => json({ message: "sent" })],
+      "/otp/verify-login-email-otp": [
+        () => json({ error: "Not allowed" }, 401),
+        () => json({ token: "a", refreshToken: "r" }),
+      ],
+    });
+
+    const codes = ["000000", "123456"];
+    const attemptsLeft: number[] = [];
+
+    const result = await completeLogin({
+      instanceUrl: INSTANCE,
+      identifier: "dev@example.com",
+      getCode: async () => codes.shift() ?? null,
+      notify: (e) => {
+        if (e.type === "incorrect") attemptsLeft.push(e.attemptsLeft);
+      },
+    });
+
+    expect(result?.tokens.accessToken).toBe("a");
+    expect(attemptsLeft).toEqual([2]);
+  });
+
+  it("gives up after the attempt cap", async () => {
+    mockRouter({
+      "/login": [
+        () => json({ token: "e1", identifierType: "email", loginMethods: ["email_otp"] }),
+      ],
+      "/otp/generate-login-email-otp": [() => json({ message: "sent" })],
+      "/otp/verify-login-email-otp": [() => json({ error: "Not allowed" }, 401)],
+    });
+
+    let asked = 0;
+    await expect(
+      completeLogin({
+        instanceUrl: INSTANCE,
+        identifier: "dev@example.com",
+        maxAttempts: 3,
+        getCode: async () => {
+          asked++;
+          return "000000";
+        },
+      }),
+    ).rejects.toBeInstanceOf(LoginError);
+
+    expect(asked).toBe(3);
+  });
+
+  it("surfaces the OTP rate limiter on generate", async () => {
+    mockRouter({
+      "/login": [
+        () => json({ token: "e1", identifierType: "email", loginMethods: ["email_otp"] }),
+      ],
+      "/otp/generate-login-email-otp": [() => json({ error: "rate limited" }, 429)],
+    });
+
+    await expect(
+      completeLogin({
+        instanceUrl: INSTANCE,
+        identifier: "dev@example.com",
+        getCode: async () => "123456",
+      }),
+    ).rejects.toThrow(/10 per 15 minutes/);
+  });
+
+  it("re-logins and resends when the ephemeral window expires, without spending an attempt", async () => {
+    let clock = 1_000;
+    const calls = mockRouter({
+      "/login": [
+        () => json({ token: "e1", identifierType: "email", loginMethods: ["email_otp"] }),
+        () => json({ token: "e2", identifierType: "email", loginMethods: ["email_otp"] }),
+      ],
+      "/otp/generate-login-email-otp": [() => json({ message: "sent" })],
+      "/otp/verify-login-email-otp": [() => json({ token: "a", refreshToken: "r" })],
+    });
+
+    let resentSeen = false;
+    const result = await completeLogin({
+      instanceUrl: INSTANCE,
+      identifier: "dev@example.com",
+      now: () => clock,
+      getCode: async ({ resent }) => {
+        if (!resentSeen) {
+          resentSeen = true;
+          clock += 6 * 60 * 1000;
+          return "123456";
+        }
+        expect(resent).toBe(true);
+        return "654321";
+      },
+      notify: () => {},
+    });
+
+    expect(result?.tokens.accessToken).toBe("a");
+    expect(calls.filter((c) => c.url.endsWith("/login"))).toHaveLength(2);
+    const verify = calls.find((c) => c.url.endsWith("/verify-login-email-otp"))!;
+    expect(authHeader(verify)).toBe("Bearer e2");
+  });
+
+  it("rejects an unverified account with a clear message", async () => {
+    mockRouter({
+      "/login": [() => json({ error: "Login failed. Need to verify." }, 401)],
+    });
+
+    await expect(
+      completeLogin({
+        instanceUrl: INSTANCE,
+        identifier: "dev@example.com",
+        getCode: async () => "123456",
+      }),
+    ).rejects.toThrow(/not verified/i);
+  });
+
+  it("rejects when email OTP is not an available login method", async () => {
+    mockRouter({
+      "/login": [
+        () => json({ token: "e1", identifierType: "email", loginMethods: ["passkey"] }),
+      ],
+    });
+
+    await expect(
+      completeLogin({
+        instanceUrl: INSTANCE,
+        identifier: "dev@example.com",
+        getCode: async () => "123456",
+      }),
+    ).rejects.toThrow(/cannot use email otp/i);
+  });
+
+  it("returns null when the user cancels the code prompt", async () => {
+    mockRouter({
+      "/login": [
+        () => json({ token: "e1", identifierType: "email", loginMethods: ["email_otp"] }),
+      ],
+      "/otp/generate-login-email-otp": [() => json({ message: "sent" })],
+    });
+
+    const result = await completeLogin({
+      instanceUrl: INSTANCE,
+      identifier: "dev@example.com",
+      getCode: async () => null,
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/core/loginFlow.ts
+++ b/src/core/loginFlow.ts
@@ -1,0 +1,249 @@
+import type { IdentifierType } from "./config.js";
+import { apiRequest, isRateLimited, joinUrl, jsonBody } from "./http.js";
+import { tokensFromAuthResponse } from "./authClient.js";
+import type { TokenBundle } from "./keychain.js";
+
+export const EPHEMERAL_WINDOW_MS = 5 * 60 * 1000;
+export const DEFAULT_MAX_ATTEMPTS = 3;
+
+export type LoginChannel = "email" | "phone";
+
+export class LoginError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LoginError";
+  }
+}
+
+export type LoginEvent =
+  | { type: "code_sent"; channel: LoginChannel }
+  | { type: "code_resent"; channel: LoginChannel }
+  | { type: "verifying" }
+  | { type: "incorrect"; attemptsLeft: number };
+
+export interface LoginResult {
+  tokens: TokenBundle;
+  identity: { sub?: string; email?: string; identifierType: IdentifierType };
+  channel: LoginChannel;
+}
+
+export interface CompleteLoginOptions {
+  instanceUrl: string;
+  identifier: string;
+  maxAttempts?: number;
+  now?: () => number;
+  getCode: (ctx: { attempt: number; resent: boolean }) => Promise<string | null>;
+  notify?: (event: LoginEvent) => void;
+}
+
+interface StartedLogin {
+  ephemeralToken: string;
+  loginMethods: string[];
+  channel: LoginChannel;
+  sub?: string;
+  deadline: number;
+}
+
+function apiMessage(data: unknown): string | undefined {
+  if (data && typeof data === "object") {
+    const record = data as Record<string, unknown>;
+    if (typeof record.error === "string") return record.error;
+    if (typeof record.message === "string") return record.message;
+  }
+  return undefined;
+}
+
+async function request(
+  instanceUrl: string,
+  url: string,
+  init: RequestInit,
+) {
+  try {
+    return await apiRequest<Record<string, unknown>>(url, init);
+  } catch {
+    throw new LoginError(
+      `Could not reach ${instanceUrl}. Check the instance URL and your connection.`,
+    );
+  }
+}
+
+async function startLogin(
+  instanceUrl: string,
+  identifier: string,
+  now: () => number,
+): Promise<StartedLogin> {
+  const res = await request(
+    instanceUrl,
+    joinUrl(instanceUrl, "/login"),
+    jsonBody("POST", { identifier }),
+  );
+
+  if (isRateLimited(res)) {
+    throw new LoginError(
+      "The instance is rate limiting requests. Wait a few minutes and try again.",
+    );
+  }
+
+  if (!res.ok) {
+    const message = apiMessage(res.data) ?? "";
+    if (res.status === 401 && /verify/i.test(message)) {
+      throw new LoginError(
+        `The account for ${identifier} is not verified yet. Finish registration, then log in.`,
+      );
+    }
+    if (res.status === 400) {
+      throw new LoginError(
+        `"${identifier}" is not a valid email or phone number.`,
+      );
+    }
+    if (res.status === 401 || res.status === 403) {
+      throw new LoginError(
+        `No account was found for ${identifier}, or login is not permitted.`,
+      );
+    }
+    throw new LoginError(`Login request failed (${res.status}).`);
+  }
+
+  const data = res.data ?? {};
+  const ephemeralToken = typeof data.token === "string" ? data.token : "";
+  if (!ephemeralToken) {
+    throw new LoginError("The instance did not return a login token.");
+  }
+
+  const loginMethods = Array.isArray(data.loginMethods)
+    ? data.loginMethods.filter((m): m is string => typeof m === "string")
+    : [];
+  const channel: LoginChannel =
+    data.identifierType === "phone" ? "phone" : "email";
+  const sub = typeof data.sub === "string" ? data.sub : undefined;
+
+  return {
+    ephemeralToken,
+    loginMethods,
+    channel,
+    sub,
+    deadline: now() + EPHEMERAL_WINDOW_MS,
+  };
+}
+
+async function sendCode(
+  instanceUrl: string,
+  started: StartedLogin,
+): Promise<void> {
+  const path =
+    started.channel === "email"
+      ? "/otp/generate-login-email-otp"
+      : "/otp/generate-login-phone-otp";
+
+  const res = await request(instanceUrl, joinUrl(instanceUrl, path), {
+    method: "GET",
+    headers: { Authorization: `Bearer ${started.ephemeralToken}` },
+  });
+
+  if (isRateLimited(res)) {
+    throw new LoginError(
+      "Too many code requests. The instance limits OTP to 10 per 15 minutes per IP. Wait and try again.",
+    );
+  }
+
+  if (!res.ok) {
+    if (res.status === 403) {
+      const label = started.channel === "email" ? "Email" : "Phone";
+      throw new LoginError(`${label} OTP login is disabled on this instance.`);
+    }
+    const message = apiMessage(res.data);
+    throw new LoginError(
+      message ? `Could not send a code: ${message}` : "Could not send a login code.",
+    );
+  }
+
+  const refreshed = typeof res.data?.token === "string" ? res.data.token : undefined;
+  if (refreshed) started.ephemeralToken = refreshed;
+}
+
+async function verifyCode(
+  instanceUrl: string,
+  started: StartedLogin,
+  code: string,
+) {
+  const path =
+    started.channel === "email"
+      ? "/otp/verify-login-email-otp"
+      : "/otp/verify-login-phone-otp";
+
+  return request(
+    instanceUrl,
+    joinUrl(instanceUrl, path),
+    jsonBody(
+      "POST",
+      { verificationToken: code },
+      { Authorization: `Bearer ${started.ephemeralToken}` },
+    ),
+  );
+}
+
+export async function completeLogin(
+  opts: CompleteLoginOptions,
+): Promise<LoginResult | null> {
+  const now = opts.now ?? (() => Date.now());
+  const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const notify = opts.notify ?? (() => {});
+
+  let started = await startLogin(opts.instanceUrl, opts.identifier, now);
+  const channel = started.channel;
+  const required = channel === "email" ? "email_otp" : "phone_otp";
+  if (started.loginMethods.length > 0 && !started.loginMethods.includes(required)) {
+    throw new LoginError(
+      `This account cannot use ${required.replace("_", " ")} login. Available methods: ${started.loginMethods.join(", ")}.`,
+    );
+  }
+
+  await sendCode(opts.instanceUrl, started);
+  notify({ type: "code_sent", channel });
+
+  let attempt = 0;
+  let resent = false;
+  while (attempt < maxAttempts) {
+    const code = await opts.getCode({ attempt: attempt + 1, resent });
+    resent = false;
+    if (code === null) return null;
+
+    if (now() >= started.deadline) {
+      started = await startLogin(opts.instanceUrl, opts.identifier, now);
+      await sendCode(opts.instanceUrl, started);
+      resent = true;
+      notify({ type: "code_resent", channel });
+      continue;
+    }
+
+    notify({ type: "verifying" });
+    const res = await verifyCode(opts.instanceUrl, started, code);
+
+    if (res.status === 200 && res.data) {
+      const tokens = tokensFromAuthResponse(res.data);
+      if (!tokens) {
+        throw new LoginError(
+          "The instance returned an unexpected verification response.",
+        );
+      }
+      const email = typeof res.data.email === "string" ? res.data.email : undefined;
+      const sub = typeof res.data.sub === "string" ? res.data.sub : started.sub;
+      return {
+        tokens,
+        identity: { sub, email, identifierType: channel },
+        channel,
+      };
+    }
+
+    if (isRateLimited(res)) {
+      throw new LoginError(
+        "Too many attempts. The instance limits OTP to 10 per 15 minutes per IP. Wait and try again.",
+      );
+    }
+
+    attempt++;
+    notify({ type: "incorrect", attemptsLeft: maxAttempts - attempt });
+  }
+
+  throw new LoginError("Could not verify a code. Run seamless login to try again.");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import pkg from "../package.json" with { type: "json" };
 import { runBootstrapAdmin } from "./commands/bootstrapAdmin.js";
 import { runVerify } from "./commands/verify.js";
 import { runProfile } from "./commands/profile.js";
+import { runLogin } from "./commands/login.js";
 
 export const VERSION = pkg.version;
 const args = process.argv.slice(2);
@@ -57,6 +58,11 @@ async function main() {
 
   if (command === "profile") {
     await runProfile(args.slice(1));
+    return;
+  }
+
+  if (command === "login") {
+    await runLogin(args.slice(1));
     return;
   }
 


### PR DESCRIPTION
## Summary

Fourth issue in the CLI auth epic (#38). Adds `seamless login`: interactive email OTP login against the active profile's Seamless Auth instance, the clean headless path for a CLI (the user pastes the code from their inbox, so nothing has to be delivered to the CLI and no service token is required).

Composes everything built so far: the active profile (#39), the OS keychain (#40), and the shared HTTP helpers (#41).

## Flow (verified against the auth-api source)

1. `POST /login { identifier }` captures the ephemeral token, `sub`, `identifierType`, and `loginMethods`.
2. Gate on `loginMethods`: if the account cannot use `email_otp` (or `phone_otp`), stop with the available methods listed.
3. `GET /otp/generate-login-email-otp` (Bearer ephemeral) sends the code.
4. Prompt for the code, then `POST /otp/verify-login-email-otp { verificationToken }` (Bearer ephemeral).
5. On success, store the rotated access/refresh pair in the keychain and persist the identity (sub, email, identifier type) on the profile.

## Constraints handled

- Caps local code retries (default 3) so it does not retry into the per-IP OTP limiter (10 per 15 minutes).
- Surfaces a `429` from generate or verify with a clear message instead of hammering.
- Respects the 5 minute ephemeral window: if it lapses before verification, re-mints the ephemeral token and resends a code without spending a retry.
- Unverified account, unknown identifier, invalid identifier, and disabled OTP each get a specific message.
- Connection failures are converted to a clear "could not reach <instance>" message, not a stack trace.

## Structure

- `src/core/loginFlow.ts`: pure orchestration (`completeLogin`) with injectable `getCode` and `now` callbacks and a `notify` event stream, so the whole flow is unit-testable.
- `src/commands/login.ts`: the `@clack/prompts` front end; also accepts the identifier positionally or via `--identifier`, and `--profile` / `SEAMLESS_PROFILE`.

## Tests / verification

- `npm run build` (tsc strict): passing.
- `npm test` (vitest): 45 passing (8 new for the login flow), driven by a routed `fetch` mock: end-to-end email OTP, retry-then-succeed, attempt-cap exhaustion, 429 on generate, ephemeral-window re-login without spending an attempt, unverified account, unavailable login method, and user cancel.
- Smoke-tested the command: no-active-profile guidance, and the unreachable-instance path now prints `Could not reach https://...` cleanly.

A live end-to-end run against the conformance stack is currently blocked by #50 (the auth-api container runs Node 20 while the package requires Node >=24, so `seamless verify` cannot stand the API up). The flow is covered here by contract-accurate unit tests built from the auth-api route and schema source. Once #50 lands I can add a conformance spec that drives `seamless login` for real (that fits naturally under #47).

## Acceptance criteria

- [x] A user with a verified account can log in end to end and the CLI holds a valid session.
- [x] Wrong codes are handled without hammering the rate limiter.
- [x] The command uses the active profile's instance URL.

Closes #42