### PR TITLE
feat(session): whoami and logout commands

### DIFF
--- a/.changeset/whoami-logout.md
+++ b/.changeset/whoami-logout.md
@@ -1,0 +1,12 @@
+---
+"seamless-cli": minor
+---
+
+Add `seamless whoami` and `seamless logout`. `whoami` calls `GET /users/me`
+through the authenticated client and prints the identity (sub, email, roles)
+alongside the active profile and instance URL, failing cleanly with a "not
+logged in" message when there is no session. `logout` ends the current session
+with `DELETE /logout` and then clears the profile's keychain tokens; `logout
+--all` revokes every session for the user with `DELETE /logout/all` first. Both
+commands accept `--profile` (and honor `SEAMLESS_PROFILE`) and always clear the
+local tokens even if the server session was already gone.

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -16,6 +16,8 @@ USAGE
   seamless verify [--api-only] [--filter=<flow>] [--keep-up]
   seamless profile <list|add|use|remove>
   seamless login [identifier] [--identifier <email>] [--profile <name>]
+  seamless whoami [--profile <name>]
+  seamless logout [--all] [--profile <name>]
   seamless --help
   seamless --version
 
@@ -65,6 +67,14 @@ COMMANDS
     --profile <name>
       • Log in against a specific profile instead of the active one
       • Also selectable with the SEAMLESS_PROFILE environment variable
+
+  whoami
+    Show the identity behind the active profile's session (sub, email, roles),
+    alongside the profile name and instance URL. Fails cleanly if not logged in.
+
+  logout [--all]
+    End the current session on the instance and clear the local keychain tokens.
+    --all revokes every session for the user before clearing local tokens.
 
   check
     Validate project setup, Docker, and running services

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,0 +1,53 @@
+import kleur from "kleur";
+import { extractFlag } from "../core/args.js";
+import { createAuthClient, ReauthRequiredError } from "../core/authClient.js";
+import { getActiveProfile } from "../core/config.js";
+import { clearLocalSession, revokeSession } from "../core/session.js";
+
+export async function runLogout(args: string[]): Promise<void> {
+  const all = args.includes("--all");
+  const { value: profileFlag } = extractFlag(
+    args.filter((a) => a !== "--all"),
+    "profile",
+  );
+
+  const profile = getActiveProfile({ profileFlag });
+  if (!profile) {
+    console.log(kleur.yellow("No active profile. Nothing to log out of."));
+    return;
+  }
+
+  let client;
+  try {
+    client = await createAuthClient({ profileFlag });
+  } catch (err) {
+    if (err instanceof ReauthRequiredError) {
+      await clearLocalSession(profile);
+      console.log(kleur.green("You are already logged out."));
+      return;
+    }
+    throw err;
+  }
+
+  let revoked = false;
+  try {
+    revoked = await revokeSession(client, { all });
+  } catch (err) {
+    if (!(err instanceof ReauthRequiredError)) throw err;
+    revoked = true;
+  }
+
+  await clearLocalSession(profile);
+
+  if (revoked) {
+    console.log(
+      kleur.green(all ? "Logged out of all sessions." : "Logged out."),
+    );
+  } else {
+    console.log(
+      kleur.yellow(
+        "Cleared the local session. The instance reported a problem revoking the session.",
+      ),
+    );
+  }
+}

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -1,0 +1,33 @@
+import kleur from "kleur";
+import { extractFlag } from "../core/args.js";
+import { createAuthClient, ReauthRequiredError } from "../core/authClient.js";
+import { fetchIdentity, type Identity } from "../core/session.js";
+import type { Profile } from "../core/config.js";
+
+export async function runWhoami(args: string[]): Promise<void> {
+  const { value: profileFlag } = extractFlag(args, "profile");
+
+  try {
+    const client = await createAuthClient({ profileFlag });
+    const identity = await fetchIdentity(client);
+    printIdentity(client.profile, identity);
+  } catch (err) {
+    if (err instanceof ReauthRequiredError) {
+      console.log(kleur.yellow(err.message));
+      process.exit(1);
+    }
+    console.error(kleur.red((err as Error).message));
+    process.exit(1);
+  }
+}
+
+function printIdentity(profile: Profile, identity: Identity): void {
+  const line = (label: string, value: string) =>
+    console.log(kleur.dim(`${label}:`.padEnd(11)) + value);
+
+  line("Profile", profile.name);
+  line("Instance", profile.instanceUrl);
+  line("Sub", identity.sub ?? profile.sub ?? "(unknown)");
+  line("Email", identity.email ?? profile.email ?? "(unknown)");
+  line("Roles", identity.roles.length ? identity.roles.join(", ") : "(none)");
+}

--- a/src/core/session.test.ts
+++ b/src/core/session.test.ts
@@ -1,0 +1,151 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AuthClient } from "./authClient.js";
+import type { ApiResponse } from "./http.js";
+import {
+  getTokens,
+  KeychainUnavailableError,
+  saveTokens,
+  setBackendForTesting,
+  type KeychainBackend,
+} from "./keychain.js";
+import { clearLocalSession, fetchIdentity, revokeSession } from "./session.js";
+
+function response<T>(status: number, data: T | null): ApiResponse<T> {
+  return { ok: status >= 200 && status < 300, status, data, headers: new Headers() };
+}
+
+const profile = { name: "default", instanceUrl: "https://auth.example.com" };
+
+function fakeClient(
+  handler: (method: string, path: string) => ApiResponse<unknown>,
+): AuthClient {
+  return {
+    profile: { ...profile },
+    get: async (path) => handler("GET", path) as never,
+    post: async (path) => handler("POST", path) as never,
+    request: async (path, init) =>
+      handler((init?.method ?? "GET").toUpperCase(), path) as never,
+  };
+}
+
+function memoryBackend(): KeychainBackend {
+  const store = new Map<string, string>();
+  return {
+    get: (account) => store.get(account) ?? null,
+    set: (account, secret) => {
+      store.set(account, secret);
+    },
+    delete: (account) => store.delete(account),
+  };
+}
+
+describe("fetchIdentity", () => {
+  it("maps the /users/me user object", async () => {
+    const client = fakeClient((method, path) => {
+      expect(method).toBe("GET");
+      expect(path).toBe("/users/me");
+      return response(200, {
+        user: {
+          id: "user-1",
+          email: "dev@example.com",
+          roles: ["admin", "user"],
+        },
+      });
+    });
+
+    const identity = await fetchIdentity(client);
+    expect(identity).toEqual({
+      sub: "user-1",
+      email: "dev@example.com",
+      roles: ["admin", "user"],
+    });
+  });
+
+  it("defaults roles to an empty array and throws on a non-ok response", async () => {
+    const ok = fakeClient(() => response(200, { user: { id: "u" } }));
+    expect((await fetchIdentity(ok)).roles).toEqual([]);
+
+    const bad = fakeClient(() => response(500, null));
+    await expect(fetchIdentity(bad)).rejects.toThrow(/could not load/i);
+  });
+});
+
+describe("revokeSession", () => {
+  it("deletes the current session by default", async () => {
+    const seen: string[] = [];
+    const client = fakeClient((method, path) => {
+      seen.push(`${method} ${path}`);
+      return response(200, { message: "ok" });
+    });
+
+    expect(await revokeSession(client)).toBe(true);
+    expect(seen).toEqual(["DELETE /logout"]);
+  });
+
+  it("deletes every session with --all", async () => {
+    const seen: string[] = [];
+    const client = fakeClient((method, path) => {
+      seen.push(`${method} ${path}`);
+      return response(200, { message: "ok" });
+    });
+
+    expect(await revokeSession(client, { all: true })).toBe(true);
+    expect(seen).toEqual(["DELETE /logout/all"]);
+  });
+
+  it("reports a non-ok revoke as false", async () => {
+    const client = fakeClient(() => response(500, null));
+    expect(await revokeSession(client)).toBe(false);
+  });
+});
+
+describe("clearLocalSession", () => {
+  let configHome: string;
+
+  beforeEach(() => {
+    configHome = fs.mkdtempSync(path.join(os.tmpdir(), "seamless-session-"));
+    process.env.XDG_CONFIG_HOME = configHome;
+    delete process.env.SEAMLESS_REFRESH_TOKEN;
+  });
+
+  afterEach(() => {
+    setBackendForTesting(null);
+    fs.rmSync(configHome, { recursive: true, force: true });
+    delete process.env.XDG_CONFIG_HOME;
+  });
+
+  it("removes the stored tokens", async () => {
+    setBackendForTesting(memoryBackend());
+    await saveTokens(profile, { accessToken: "a", refreshToken: "r" });
+
+    await clearLocalSession(profile);
+    expect(await getTokens(profile)).toBeNull();
+  });
+
+  it("does not throw when the keychain is unavailable", async () => {
+    setBackendForTesting({
+      get: () => null,
+      set: () => {},
+      delete: () => {
+        throw new KeychainUnavailableError();
+      },
+    });
+
+    await expect(clearLocalSession(profile)).resolves.toBeUndefined();
+  });
+
+  it("propagates unexpected errors", async () => {
+    setBackendForTesting({
+      get: () => null,
+      set: () => {},
+      delete: () => {
+        throw new Error("disk on fire");
+      },
+    });
+
+    await expect(clearLocalSession(profile)).rejects.toThrow(/disk on fire/);
+  });
+});

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -1,0 +1,44 @@
+import type { AuthClient } from "./authClient.js";
+import type { Profile } from "./config.js";
+import { deleteTokens, KeychainUnavailableError } from "./keychain.js";
+
+export interface Identity {
+  sub?: string;
+  email?: string;
+  roles: string[];
+}
+
+export async function fetchIdentity(client: AuthClient): Promise<Identity> {
+  const res = await client.get<Record<string, unknown>>("/users/me");
+  if (!res.ok) {
+    throw new Error(`Could not load your identity (${res.status}).`);
+  }
+
+  const user = (res.data?.user ?? {}) as Record<string, unknown>;
+  return {
+    sub: typeof user.id === "string" ? user.id : undefined,
+    email: typeof user.email === "string" ? user.email : undefined,
+    roles: Array.isArray(user.roles)
+      ? user.roles.filter((role): role is string => typeof role === "string")
+      : [],
+  };
+}
+
+export async function revokeSession(
+  client: AuthClient,
+  opts: { all?: boolean } = {},
+): Promise<boolean> {
+  const path = opts.all ? "/logout/all" : "/logout";
+  const res = await client.request(path, { method: "DELETE" });
+  return res.ok;
+}
+
+export async function clearLocalSession(
+  profile: Pick<Profile, "name" | "instanceUrl">,
+): Promise<void> {
+  try {
+    await deleteTokens(profile);
+  } catch (err) {
+    if (!(err instanceof KeychainUnavailableError)) throw err;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import { runBootstrapAdmin } from "./commands/bootstrapAdmin.js";
 import { runVerify } from "./commands/verify.js";
 import { runProfile } from "./commands/profile.js";
 import { runLogin } from "./commands/login.js";
+import { runWhoami } from "./commands/whoami.js";
+import { runLogout } from "./commands/logout.js";
 
 export const VERSION = pkg.version;
 const args = process.argv.slice(2);
@@ -63,6 +65,16 @@ async function main() {
 
   if (command === "login") {
     await runLogin(args.slice(1));
+    return;
+  }
+
+  if (command === "whoami") {
+    await runWhoami(args.slice(1));
+    return;
+  }
+
+  if (command === "logout") {
+    await runLogout(args.slice(1));
     return;
   }
 


### PR DESCRIPTION
## Summary

Fifth issue in the CLI auth epic (#38). Adds `seamless whoami` and `seamless logout`, the first consumers of the authenticated client (#41) against a stored session (#40).

## Commands

- `seamless whoami`: calls `GET /users/me` through the authenticated client and prints the identity (sub, email, roles) alongside the active profile name and instance URL. Fails cleanly (exit 1, no stack) with a "not logged in" message when there is no session.
- `seamless logout`: `DELETE /logout` to end the current session, then clears the profile's keychain tokens.
- `seamless logout --all`: `DELETE /logout/all` to revoke every session for the user, then clears local tokens.

Both accept `--profile` and honor `SEAMLESS_PROFILE`. `logout` always clears the local tokens even if the server session was already gone (invalid/expired), and is idempotent (exit 0) when there is nothing to log out of.

## Endpoint note

The issue lists `GET /users` for whoami, but in the auth-api that path is the admin user list (`requireAdmin`). The authenticated-self endpoint is `GET /users/me` (`auth: access`, returns `{ user: { id, email, roles, ... } }`), which is what "authenticated user" refers to, so whoami uses `/users/me`.

## Structure

- `src/core/session.ts`: `fetchIdentity`, `revokeSession`, `clearLocalSession`, unit tested against an injected `AuthClient`.
- `src/commands/whoami.ts` and `src/commands/logout.ts`: thin front ends.

## Tests / verification

- `npm run build` (tsc strict): passing.
- `npm test` (vitest): 53 passing (8 new): `/users/me` mapping, empty-roles default, non-ok identity error, `DELETE /logout` vs `/logout/all` routing, non-ok revoke reported as false, local token clearing, and keychain-unavailable tolerance vs unexpected-error propagation.
- Smoke-tested the no-session paths: `whoami` prints the profile-specific "no session" message and exits 1; `logout` prints "already logged out" and exits 0; no-active-profile is handled for both.

As with #42, a live authenticated run is currently blocked by #50 (the conformance stack cannot start the auth-api on Node 20 vs the `>=24` engine). The logic here is covered by injected-client unit tests, and a real drive-through fits under #47 once #50 lands.

## Acceptance criteria

- [x] `whoami` reflects the current profile and fails cleanly when not logged in.
- [x] `logout` invalidates the server session and removes local tokens.
- [x] `logout --all` revokes every session for the user.

Closes #43