### PR TITLE
feat(sessions): sessions list and revoke command

### DIFF
--- a/.changeset/sessions-command.md
+++ b/.changeset/sessions-command.md
@@ -1,0 +1,12 @@
+---
+"seamless-cli": minor
+---
+
+Add `seamless sessions` to list and revoke the logged-in user's active sessions.
+`seamless sessions` (or `sessions list`) calls `GET /sessions` and renders each
+session's id, device or user agent, IP, and last-used time, marking the current
+session. `seamless sessions revoke <id>` calls `DELETE /sessions/:id`, and
+`seamless sessions revoke --all` calls `DELETE /sessions`. Revoking the current
+session, or all sessions, prompts for confirmation first and then clears the
+local keychain tokens, since that request signs you out. Accepts `--profile` and
+honors `SEAMLESS_PROFILE`.

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -18,6 +18,8 @@ USAGE
   seamless login [identifier] [--identifier <email>] [--profile <name>]
   seamless whoami [--profile <name>]
   seamless logout [--all] [--profile <name>]
+  seamless sessions [list]
+  seamless sessions revoke <id | --all>
   seamless --help
   seamless --version
 
@@ -75,6 +77,14 @@ COMMANDS
   logout [--all]
     End the current session on the instance and clear the local keychain tokens.
     --all revokes every session for the user before clearing local tokens.
+
+  sessions [list]
+    List the active sessions for the logged-in user, with the current session
+    marked. Shows the session id, device or user agent, IP, and last-used time.
+
+  sessions revoke <id | --all>
+    Revoke one session by id, or every session with --all. Revoking the current
+    session (or --all) prompts for confirmation and then clears local tokens.
 
   check
     Validate project setup, Docker, and running services

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1,0 +1,142 @@
+import { confirm, isCancel } from "@clack/prompts";
+import kleur from "kleur";
+import { extractFlag } from "../core/args.js";
+import { createAuthClient, ReauthRequiredError, type AuthClient } from "../core/authClient.js";
+import { clearLocalSession } from "../core/session.js";
+import {
+  listSessions,
+  revokeAllSessions,
+  revokeSessionById,
+  type SessionInfo,
+} from "../core/sessions.js";
+
+export async function runSessions(args: string[]): Promise<void> {
+  const sub = args[0] === "list" || args[0] === "revoke" ? args[0] : undefined;
+  const rest = sub ? args.slice(1) : args;
+  const { value: profileFlag, rest: positional } = extractFlag(rest, "profile");
+
+  try {
+    const client = await createAuthClient({ profileFlag });
+    if (sub === "revoke") {
+      await revoke(client, positional);
+    } else {
+      await list(client);
+    }
+  } catch (err) {
+    if (err instanceof ReauthRequiredError) {
+      console.log(kleur.yellow(err.message));
+      process.exit(1);
+    }
+    console.error(kleur.red((err as Error).message));
+    process.exit(1);
+  }
+}
+
+async function list(client: AuthClient): Promise<void> {
+  const sessions = await listSessions(client);
+  if (sessions.length === 0) {
+    console.log(kleur.dim("No active sessions."));
+    return;
+  }
+
+  for (const session of sessions) {
+    printSession(session);
+  }
+}
+
+async function revoke(client: AuthClient, positional: string[]): Promise<void> {
+  const all = positional.includes("--all");
+  const id = positional.find((arg) => !arg.startsWith("--"));
+
+  if (all) {
+    const proceed = await confirm({
+      message:
+        "Revoke every session, including this one? You will be signed out here.",
+      initialValue: false,
+    });
+    if (isCancel(proceed) || !proceed) {
+      console.log("Cancelled.");
+      return;
+    }
+
+    const res = await revokeAllSessions(client);
+    if (!res.ok) {
+      console.error(kleur.red(`Could not revoke sessions (${res.status}).`));
+      process.exit(1);
+    }
+    await clearLocalSession(client.profile);
+    console.log(kleur.green("Revoked all sessions."));
+    console.log(
+      kleur.dim("Local tokens cleared. Run seamless login to sign in again."),
+    );
+    return;
+  }
+
+  if (!id) {
+    console.error(
+      kleur.red("Usage: seamless sessions revoke <id> | seamless sessions revoke --all"),
+    );
+    process.exit(1);
+  }
+
+  const sessions = await listSessions(client);
+  const isCurrent = sessions.find((session) => session.id === id)?.current ?? false;
+
+  if (isCurrent) {
+    const proceed = await confirm({
+      message: "This is your current session. Revoking it signs you out here. Continue?",
+      initialValue: false,
+    });
+    if (isCancel(proceed) || !proceed) {
+      console.log("Cancelled.");
+      return;
+    }
+  }
+
+  const res = await revokeSessionById(client, id);
+  if (res.status === 404) {
+    console.log(
+      kleur.yellow(`No active session ${id}. It may already be revoked.`),
+    );
+    return;
+  }
+  if (!res.ok) {
+    console.error(kleur.red(`Could not revoke session ${id} (${res.status}).`));
+    process.exit(1);
+  }
+
+  console.log(kleur.green(`Revoked session ${id}.`));
+  if (isCurrent) {
+    await clearLocalSession(client.profile);
+    console.log(
+      kleur.dim(
+        "That was your current session; local tokens cleared. Run seamless login to sign in again.",
+      ),
+    );
+  }
+}
+
+function printSession(session: SessionInfo): void {
+  const marker = session.current ? kleur.green("* ") : "  ";
+  const device =
+    session.deviceName ?? shortUserAgent(session.userAgent) ?? "unknown device";
+  const ip = session.ipAddress ?? "unknown ip";
+  const when = session.lastUsedAt ? formatWhen(session.lastUsedAt) : "unknown";
+
+  console.log(marker + kleur.bold(session.id));
+  console.log(`    ${device}  ${kleur.dim(ip)}`);
+  console.log(
+    kleur.dim(`    last used ${when}${session.current ? "  (current)" : ""}`),
+  );
+}
+
+function shortUserAgent(userAgent?: string): string | undefined {
+  if (!userAgent) return undefined;
+  return userAgent.length > 48 ? `${userAgent.slice(0, 45)}...` : userAgent;
+}
+
+function formatWhen(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return `${date.toISOString().slice(0, 16).replace("T", " ")} UTC`;
+}

--- a/src/core/sessions.test.ts
+++ b/src/core/sessions.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type { AuthClient } from "./authClient.js";
+import type { ApiResponse } from "./http.js";
+import {
+  listSessions,
+  revokeAllSessions,
+  revokeSessionById,
+} from "./sessions.js";
+
+function response<T>(status: number, data: T | null): ApiResponse<T> {
+  return { ok: status >= 200 && status < 300, status, data, headers: new Headers() };
+}
+
+function fakeClient(
+  handler: (method: string, path: string) => ApiResponse<unknown>,
+): AuthClient {
+  return {
+    profile: { name: "default", instanceUrl: "https://auth.example.com" },
+    get: async (path) => handler("GET", path) as never,
+    post: async (path) => handler("POST", path) as never,
+    request: async (path, init) =>
+      handler((init?.method ?? "GET").toUpperCase(), path) as never,
+  };
+}
+
+describe("listSessions", () => {
+  it("maps the session list and the current marker", async () => {
+    const client = fakeClient((method, path) => {
+      expect(`${method} ${path}`).toBe("GET /sessions");
+      return response(200, {
+        total: 2,
+        sessions: [
+          {
+            id: "s1",
+            deviceName: "MacBook",
+            ipAddress: "203.0.113.4",
+            userAgent: "curl/8",
+            lastUsedAt: "2026-07-13T10:00:00.000Z",
+            expiresAt: "2026-07-20T10:00:00.000Z",
+            current: true,
+          },
+          { id: "s2", current: false },
+        ],
+      });
+    });
+
+    const sessions = await listSessions(client);
+    expect(sessions).toHaveLength(2);
+    expect(sessions[0]).toMatchObject({
+      id: "s1",
+      deviceName: "MacBook",
+      ipAddress: "203.0.113.4",
+      current: true,
+    });
+    expect(sessions[1]).toEqual({ id: "s2", current: false });
+  });
+
+  it("drops malformed entries and throws on a non-ok response", async () => {
+    const withJunk = fakeClient(() =>
+      response(200, { sessions: [{ id: "ok", current: false }, {}, 42, null] }),
+    );
+    expect(await listSessions(withJunk)).toEqual([{ id: "ok", current: false }]);
+
+    const bad = fakeClient(() => response(500, null));
+    await expect(listSessions(bad)).rejects.toThrow(/could not list/i);
+  });
+});
+
+describe("revokeSessionById", () => {
+  it("deletes by id and URL-encodes it", async () => {
+    const seen: string[] = [];
+    const client = fakeClient((method, path) => {
+      seen.push(`${method} ${path}`);
+      return response(200, { message: "ok" });
+    });
+
+    const res = await revokeSessionById(client, "a b/c");
+    expect(res).toEqual({ ok: true, status: 200 });
+    expect(seen).toEqual(["DELETE /sessions/a%20b%2Fc"]);
+  });
+
+  it("surfaces a 404 for an unknown session", async () => {
+    const client = fakeClient(() => response(404, { error: "Session not found" }));
+    expect(await revokeSessionById(client, "gone")).toEqual({
+      ok: false,
+      status: 404,
+    });
+  });
+});
+
+describe("revokeAllSessions", () => {
+  it("deletes the collection", async () => {
+    const seen: string[] = [];
+    const client = fakeClient((method, path) => {
+      seen.push(`${method} ${path}`);
+      return response(200, { message: "ok" });
+    });
+
+    const res = await revokeAllSessions(client);
+    expect(res).toEqual({ ok: true, status: 200 });
+    expect(seen).toEqual(["DELETE /sessions"]);
+  });
+});

--- a/src/core/sessions.ts
+++ b/src/core/sessions.ts
@@ -1,0 +1,66 @@
+import type { AuthClient } from "./authClient.js";
+
+export interface SessionInfo {
+  id: string;
+  deviceName?: string;
+  ipAddress?: string;
+  userAgent?: string;
+  lastUsedAt?: string;
+  expiresAt?: string;
+  current: boolean;
+}
+
+function str(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value ? value : undefined;
+}
+
+function toSessionInfo(raw: unknown): SessionInfo | null {
+  if (!raw || typeof raw !== "object") return null;
+  const record = raw as Record<string, unknown>;
+  if (typeof record.id !== "string") return null;
+
+  return {
+    id: record.id,
+    deviceName: str(record, "deviceName"),
+    ipAddress: str(record, "ipAddress"),
+    userAgent: str(record, "userAgent"),
+    lastUsedAt: str(record, "lastUsedAt"),
+    expiresAt: str(record, "expiresAt"),
+    current: record.current === true,
+  };
+}
+
+export async function listSessions(client: AuthClient): Promise<SessionInfo[]> {
+  const res = await client.get<{ sessions?: unknown[] }>("/sessions");
+  if (!res.ok) {
+    throw new Error(`Could not list sessions (${res.status}).`);
+  }
+
+  const raw = Array.isArray(res.data?.sessions) ? res.data.sessions : [];
+  return raw
+    .map(toSessionInfo)
+    .filter((session): session is SessionInfo => session !== null);
+}
+
+export interface RevokeResult {
+  ok: boolean;
+  status: number;
+}
+
+export async function revokeSessionById(
+  client: AuthClient,
+  id: string,
+): Promise<RevokeResult> {
+  const res = await client.request(`/sessions/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
+  return { ok: res.ok, status: res.status };
+}
+
+export async function revokeAllSessions(
+  client: AuthClient,
+): Promise<RevokeResult> {
+  const res = await client.request("/sessions", { method: "DELETE" });
+  return { ok: res.ok, status: res.status };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { runProfile } from "./commands/profile.js";
 import { runLogin } from "./commands/login.js";
 import { runWhoami } from "./commands/whoami.js";
 import { runLogout } from "./commands/logout.js";
+import { runSessions } from "./commands/sessions.js";
 
 export const VERSION = pkg.version;
 const args = process.argv.slice(2);
@@ -75,6 +76,11 @@ async function main() {
 
   if (command === "logout") {
     await runLogout(args.slice(1));
+    return;
+  }
+
+  if (command === "sessions") {
+    await runSessions(args.slice(1));
     return;
   }
 


### PR DESCRIPTION
## Summary

Sixth issue in the CLI auth epic (#38). Adds `seamless sessions` to list and revoke the logged-in user's active sessions from the terminal, built on the authenticated client (#41).

## Commands

- `seamless sessions` (or `sessions list`): `GET /sessions`, renders each session's id, device or user agent, IP, and last-used time, with the current session marked (`*`).
- `seamless sessions revoke <id>`: `DELETE /sessions/:id`. A 404 is reported as "may already be revoked" rather than an error.
- `seamless sessions revoke --all`: `DELETE /sessions`.

Revoking the current session (detected via the `current` flag on the list) or `--all` prompts for confirmation first, and on success clears the local keychain tokens, since that request signs the CLI out. `--profile` / `SEAMLESS_PROFILE` are honored. Not-logged-in fails cleanly with the "run seamless login" message.

## Contract note

The serialized session (from the auth-api `serializeSession`) exposes `id`, `deviceName`, `ipAddress`, `userAgent`, `lastUsedAt`, `expiresAt`, and `current`. There is no `createdAt` in the payload, so the list shows `lastUsedAt` (the issue mentioned created and last-used; only last-used is available from the API).

## Structure

- `src/core/sessions.ts`: `listSessions`, `revokeSessionById`, `revokeAllSessions`, unit tested against an injected `AuthClient`.
- `src/commands/sessions.ts`: the `@clack/prompts` front end (rendering + confirmation).

## Tests / verification

- `npm run build` (tsc strict): passing.
- `npm test` (vitest): 58 passing (5 new): list mapping with the current marker, malformed-entry filtering, non-ok list error, revoke-by-id with URL encoding, 404 surfaced, and revoke-all routing.
- Smoke-tested the not-logged-in paths for `sessions` and `sessions revoke` (clean message, exit 1).

Live end-to-end remains blocked by #50 (conformance stack cannot start the auth-api on Node 20 vs the `>=24` engine); the logic is covered by injected-client unit tests, and a real drive-through fits under #47 once #50 lands.

## Acceptance criteria

- [x] Listing shows all active sessions for the user.
- [x] Revoking a session is reflected on the next list (server-side revoke via the documented endpoints).
- [x] Revoking the current session prompts for confirmation first.

Closes #44