### PR TITLE
chore(templates): scaffold from seamless-templates v0.2.4

### DIFF
--- a/.changeset/bump-templates-v0-2-4.md
+++ b/.changeset/bump-templates-v0-2-4.md
@@ -1,0 +1,7 @@
+---
+"seamless-cli": patch
+---
+
+chore(templates): scaffold from seamless-templates v0.2.4
+
+Bump `SEAMLESS_TEMPLATES_REF` to `v0.2.4`. The Express template now has a working production `npm run start` (fixed extensionless ESM imports and the migration runner path) and ships the `docker-compose.yml` its scripts and README referenced. The web templates (react-vite and react-oauth) drop the unused `VITE_AUTH_SERVER_URL`, and all templates document both the local and managed init paths.

--- a/src/core/images.ts
+++ b/src/core/images.ts
@@ -13,4 +13,4 @@ export const SEAMLESS_AUTH_ADMIN_DASHBOARD_IMAGE = `ghcr.io/fells-code/seamless-
 // SEAMLESS_TEMPLATES_REF, or point at a local checkout with SEAMLESS_TEMPLATES_DIR.
 export const SEAMLESS_TEMPLATES_REPO = "fells-code/seamless-templates";
 
-export const SEAMLESS_TEMPLATES_REF = "v0.2.3";
+export const SEAMLESS_TEMPLATES_REF = "v0.2.4";


### PR DESCRIPTION
## Summary

Bump `SEAMLESS_TEMPLATES_REF` from `v0.2.3` to `v0.2.4` so `seamless init` scaffolds from the latest starter templates.

## What changed in templates v0.2.4

- **Express**: fixes the production `npm run start` path (extensionless ESM imports now carry `.js`, the migration runner uses the source `config/config.js`), and adds the `docker-compose.yml` the README and `docker:*` scripts referenced but that did not exist.
- **Web (react-vite, react-oauth)**: drop the unused `VITE_AUTH_SERVER_URL`; both apps reach the auth server through the API, so `VITE_API_URL` is the only value the CLI fills.
- All templates now document both the local and managed (CLI-filled) init paths.

## Checks

- `npm run build` passes
- `npm test` passes (94 passed, 4 skipped)

Changeset included (patch).