### PR TITLE
refactor: target bootstrap-admin at the active profile instance

### DIFF
--- a/.changeset/bootstrap-admin-profile-targeting.md
+++ b/.changeset/bootstrap-admin-profile-targeting.md
@@ -1,0 +1,5 @@
+---
+"seamless-cli": minor
+---
+
+Target `bootstrap-admin` at the active profile's instance URL instead of requiring a local `seamless.config.json`. The command now resolves the instance from the active profile (respecting `--profile` and `SEAMLESS_PROFILE`), with `SEAMLESS_API_URL` as an override and `http://localhost:3000` as the fallback when no profile is configured. The bootstrap-secret auth flow is unchanged.

--- a/src/commands/bootstrapAdmin.test.ts
+++ b/src/commands/bootstrapAdmin.test.ts
@@ -1,19 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import fs from "fs";
 
 import { resolveBootstrapSecret } from "../core/bootstrapSecret.js";
+import { getActiveProfile } from "../core/config.js";
 import { runBootstrapAdmin } from "./bootstrapAdmin.js";
-
-vi.mock("fs", () => {
-  const fns = {
-    existsSync: vi.fn(),
-    readFileSync: vi.fn(),
-  };
-  return { default: fns, ...fns };
-});
 
 vi.mock("../core/bootstrapSecret.js", () => ({
   resolveBootstrapSecret: vi.fn(),
+}));
+
+vi.mock("../core/config.js", () => ({
+  getActiveProfile: vi.fn(),
 }));
 
 vi.mock("@clack/prompts", () => ({
@@ -26,8 +22,6 @@ vi.mock("@clack/prompts", () => ({
 
 import { intro, outro, text, confirm, spinner } from "@clack/prompts";
 
-const CONFIG_JSON = JSON.stringify({ services: { auth: { mode: "local" } } });
-
 let logs: string[];
 let errors: string[];
 let exitSpy: ReturnType<typeof vi.spyOn>;
@@ -39,17 +33,15 @@ beforeEach(() => {
   logs = [];
   errors = [];
 
-  vi.mocked(fs.existsSync).mockReset();
-  vi.mocked(fs.readFileSync).mockReset();
   vi.mocked(resolveBootstrapSecret).mockReset();
+  vi.mocked(getActiveProfile).mockReset();
   vi.mocked(intro).mockReset();
   vi.mocked(outro).mockReset();
   vi.mocked(text).mockReset();
   vi.mocked(confirm).mockReset();
   vi.mocked(spinner).mockReset();
 
-  vi.mocked(fs.existsSync).mockReturnValue(true);
-  vi.mocked(fs.readFileSync).mockReturnValue(CONFIG_JSON);
+  vi.mocked(getActiveProfile).mockReturnValue(undefined);
   vi.mocked(confirm).mockResolvedValue(true);
 
   spinnerStart = vi.fn();
@@ -89,17 +81,6 @@ function errOutput(): string {
   return errors.join("\n");
 }
 
-describe("runBootstrapAdmin — config loading", () => {
-  it("throws when seamless.config.json is missing", async () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
-
-    await expect(runBootstrapAdmin("admin@example.com")).rejects.toThrow(
-      "No seamless.config.json found. Run init first.",
-    );
-    expect(intro).toHaveBeenCalledWith("Seamless Auth Bootstrap");
-  });
-});
-
 describe("runBootstrapAdmin — email prompt", () => {
   it("uses the provided email argument without prompting", async () => {
     vi.mocked(resolveBootstrapSecret).mockReturnValue("auto-secret");
@@ -108,7 +89,7 @@ describe("runBootstrapAdmin — email prompt", () => {
       json: async () => ({ data: {} }),
     } as Response);
 
-    await runBootstrapAdmin("admin@example.com");
+    await runBootstrapAdmin(["admin@example.com"]);
 
     expect(text).not.toHaveBeenCalled();
     expect(output()).toContain("Invite sent to admin@example.com");
@@ -121,7 +102,7 @@ describe("runBootstrapAdmin — email prompt", () => {
       json: async () => ({ data: {} }),
     } as Response);
 
-    await runBootstrapAdmin();
+    await runBootstrapAdmin([]);
 
     expect(text).toHaveBeenCalledWith(
       expect.objectContaining({ message: "Admin email address" }),
@@ -136,7 +117,7 @@ describe("runBootstrapAdmin — email prompt", () => {
       json: async () => ({ data: {} }),
     } as Response);
 
-    await runBootstrapAdmin();
+    await runBootstrapAdmin([]);
 
     const call = vi.mocked(text).mock.calls[0][0] as {
       validate: (v?: string) => string | undefined;
@@ -151,7 +132,7 @@ describe("runBootstrapAdmin — confirm cancellation", () => {
   it("outputs Cancelled and returns without calling fetch", async () => {
     vi.mocked(confirm).mockResolvedValue(false);
 
-    await runBootstrapAdmin("admin@example.com");
+    await runBootstrapAdmin(["admin@example.com"]);
 
     expect(outro).toHaveBeenCalledWith("Cancelled.");
     expect(fetch).not.toHaveBeenCalled();
@@ -159,13 +140,13 @@ describe("runBootstrapAdmin — confirm cancellation", () => {
 });
 
 describe("runBootstrapAdmin — API URL resolution", () => {
-  it("defaults to localhost:3000 when SEAMLESS_API_URL is unset", async () => {
+  it("defaults to localhost:3000 when no profile or override is set", async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
       json: async () => ({ data: {} }),
     } as Response);
 
-    await runBootstrapAdmin("admin@example.com");
+    await runBootstrapAdmin(["admin@example.com"]);
 
     expect(fetch).toHaveBeenCalledWith(
       "http://localhost:3000/auth/internal/bootstrap/admin-invite",
@@ -173,15 +154,57 @@ describe("runBootstrapAdmin — API URL resolution", () => {
     );
   });
 
-  it("uses SEAMLESS_API_URL when set", async () => {
-    process.env.SEAMLESS_API_URL = "https://api.example.com";
+  it("targets the active profile's instance URL", async () => {
+    vi.mocked(getActiveProfile).mockReturnValue({
+      name: "prod",
+      instanceUrl: "https://auth.prod.example.com",
+    });
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
       json: async () => ({ data: {} }),
     } as Response);
 
-    await runBootstrapAdmin("admin@example.com");
+    await runBootstrapAdmin(["admin@example.com"]);
 
+    expect(fetch).toHaveBeenCalledWith(
+      "https://auth.prod.example.com/auth/internal/bootstrap/admin-invite",
+      expect.anything(),
+    );
+  });
+
+  it("resolves the profile named by the --profile flag", async () => {
+    vi.mocked(getActiveProfile).mockReturnValue({
+      name: "staging",
+      instanceUrl: "https://auth.staging.example.com",
+    });
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: {} }),
+    } as Response);
+
+    await runBootstrapAdmin(["--profile", "staging", "admin@example.com"]);
+
+    expect(getActiveProfile).toHaveBeenCalledWith({ profileFlag: "staging" });
+    expect(fetch).toHaveBeenCalledWith(
+      "https://auth.staging.example.com/auth/internal/bootstrap/admin-invite",
+      expect.anything(),
+    );
+  });
+
+  it("lets SEAMLESS_API_URL override the profile", async () => {
+    process.env.SEAMLESS_API_URL = "https://api.example.com";
+    vi.mocked(getActiveProfile).mockReturnValue({
+      name: "prod",
+      instanceUrl: "https://auth.prod.example.com",
+    });
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: {} }),
+    } as Response);
+
+    await runBootstrapAdmin(["admin@example.com"]);
+
+    expect(getActiveProfile).not.toHaveBeenCalled();
     expect(fetch).toHaveBeenCalledWith(
       "https://api.example.com/auth/internal/bootstrap/admin-invite",
       expect.anything(),
@@ -197,7 +220,7 @@ describe("runBootstrapAdmin — bootstrap secret resolution", () => {
       json: async () => ({ data: {} }),
     } as Response);
 
-    await runBootstrapAdmin("admin@example.com");
+    await runBootstrapAdmin(["admin@example.com"]);
 
     expect(text).not.toHaveBeenCalled();
     expect(output()).toContain("Using bootstrap secret from local environment");
@@ -215,7 +238,7 @@ describe("runBootstrapAdmin — bootstrap secret resolution", () => {
       json: async () => ({ data: {} }),
     } as Response);
 
-    await runBootstrapAdmin("admin@example.com");
+    await runBootstrapAdmin(["admin@example.com"]);
 
     expect(text).toHaveBeenCalledWith(
       expect.objectContaining({ message: "Bootstrap secret" }),
@@ -235,7 +258,7 @@ describe("runBootstrapAdmin — bootstrap secret resolution", () => {
       json: async () => ({ data: {} }),
     } as Response);
 
-    await runBootstrapAdmin("admin@example.com");
+    await runBootstrapAdmin(["admin@example.com"]);
 
     const call = vi.mocked(text).mock.calls[0][0] as {
       validate: (v?: string) => string | undefined;
@@ -253,7 +276,7 @@ describe("runBootstrapAdmin — request outcomes", () => {
       json: async () => ({ data: { url: "https://auth.example.com/register/abc" } }),
     } as Response);
 
-    await runBootstrapAdmin("admin@example.com");
+    await runBootstrapAdmin(["admin@example.com"]);
 
     expect(spinnerStart).toHaveBeenCalledWith("Creating bootstrap invite...");
     expect(spinnerStop).toHaveBeenCalledWith("Done");
@@ -269,7 +292,7 @@ describe("runBootstrapAdmin — request outcomes", () => {
       json: async () => ({ data: {} }),
     } as Response);
 
-    await runBootstrapAdmin("admin@example.com");
+    await runBootstrapAdmin(["admin@example.com"]);
 
     expect(output()).toContain("Invite sent to admin@example.com");
   });
@@ -281,7 +304,7 @@ describe("runBootstrapAdmin — request outcomes", () => {
       json: async () => ({ error: "already bootstrapped" }),
     } as Response);
 
-    await expect(runBootstrapAdmin("admin@example.com")).rejects.toThrow(
+    await expect(runBootstrapAdmin(["admin@example.com"])).rejects.toThrow(
       "process.exit(1)",
     );
 
@@ -294,7 +317,7 @@ describe("runBootstrapAdmin — request outcomes", () => {
     vi.mocked(resolveBootstrapSecret).mockReturnValue("secret");
     vi.mocked(fetch).mockRejectedValue(new Error("network down"));
 
-    await expect(runBootstrapAdmin("admin@example.com")).rejects.toThrow(
+    await expect(runBootstrapAdmin(["admin@example.com"])).rejects.toThrow(
       "process.exit(1)",
     );
 

--- a/src/commands/bootstrapAdmin.ts
+++ b/src/commands/bootstrapAdmin.ts
@@ -1,33 +1,30 @@
-import fs from "fs";
-import path from "path";
 import { intro, outro, text, confirm, spinner } from "@clack/prompts";
 import kleur from "kleur";
+import { extractFlag } from "../core/args.js";
+import { getActiveProfile } from "../core/config.js";
 import { resolveBootstrapSecret } from "../core/bootstrapSecret.js";
 
-type SeamlessConfig = {
-  services: {
-    auth: {
-      mode: "local" | "docker";
-    };
-  };
-};
+const DEFAULT_API_URL = "http://localhost:3000";
 
-function loadConfig(): SeamlessConfig {
-  const configPath = path.join(process.cwd(), "seamless.config.json");
+// Bootstrap authenticates with the shared bootstrap secret (not a user
+// session), so the profile is only used to target the right instance. The
+// SEAMLESS_API_URL env override wins for backward compatibility; otherwise fall
+// back to the local dev default when no profile is configured.
+function resolveApiUrl(profileFlag?: string): string {
+  const override = process.env.SEAMLESS_API_URL?.trim();
+  if (override) return override;
 
-  if (!fs.existsSync(configPath)) {
-    throw new Error("No seamless.config.json found. Run init first.");
-  }
+  const profile = getActiveProfile({ profileFlag });
+  if (profile) return profile.instanceUrl;
 
-  return JSON.parse(fs.readFileSync(configPath, "utf-8"));
+  return DEFAULT_API_URL;
 }
 
-export async function runBootstrapAdmin(emailArg?: string) {
+export async function runBootstrapAdmin(args: string[] = []) {
   intro("Seamless Auth Bootstrap");
 
-  const config = loadConfig();
-
-  let email = emailArg;
+  const { value: profileFlag, rest } = extractFlag(args, "profile");
+  let email = rest.find((a) => !a.startsWith("-"));
 
   if (!email) {
     email = (await text({
@@ -51,11 +48,7 @@ export async function runBootstrapAdmin(emailArg?: string) {
     return;
   }
 
-  let apiUrl = process.env.SEAMLESS_API_URL;
-
-  if (!apiUrl) {
-    apiUrl = "http://localhost:3000";
-  }
+  const apiUrl = resolveApiUrl(profileFlag);
 
   let secret = resolveBootstrapSecret();
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -12,7 +12,7 @@ USAGE
 
   seamless init [project-name] [--<example>]
   seamless check
-  seamless bootstrap-admin [email]
+  seamless bootstrap-admin [email] [--profile <name>]
   seamless verify [--api-only] [--filter=<flow>] [--keep-up]
   seamless profile <list|add|use|remove>
   seamless login [identifier] [--identifier <email>] [--profile <name>]
@@ -146,8 +146,12 @@ COMMANDS
     seamless-auth-server, override with SEAMLESS_SERVER_DIR) instead of the
     published npm packages — so you can catch SDK regressions before publishing.
 
-  bootstrap-admin [email]
+  bootstrap-admin [email] [--profile <name>]
     Create a bootstrap admin invite
+
+    Targets the active profile's instance URL (override with --profile or
+    SEAMLESS_API_URL). Falls back to http://localhost:3000 when no profile is
+    configured.
 
     Automatically resolves bootstrap secret from:
       • .env
@@ -159,6 +163,7 @@ COMMANDS
     Examples:
       seamless bootstrap-admin
       seamless bootstrap-admin admin@example.com
+      seamless bootstrap-admin admin@example.com --profile prod
 
 ────────────────────────────────────────────
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -83,10 +83,14 @@ describe("index dispatcher", () => {
     expect(runCheck).toHaveBeenCalledTimes(1);
   });
 
-  it("dispatches bootstrap-admin with the email argument", async () => {
-    await dispatch(["bootstrap-admin", "admin@example.com"]);
+  it("dispatches bootstrap-admin with the remaining arguments", async () => {
+    await dispatch(["bootstrap-admin", "--profile", "prod", "admin@example.com"]);
     const { runBootstrapAdmin } = await import("./commands/bootstrapAdmin.js");
-    expect(runBootstrapAdmin).toHaveBeenCalledWith("admin@example.com");
+    expect(runBootstrapAdmin).toHaveBeenCalledWith([
+      "--profile",
+      "prod",
+      "admin@example.com",
+    ]);
   });
 
   it("dispatches verify with the remaining args", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,8 +62,7 @@ async function main() {
   }
 
   if (command === "bootstrap-admin") {
-    const email = args[1];
-    await runBootstrapAdmin(email);
+    await runBootstrapAdmin(args.slice(1));
     return;
   }
 


### PR DESCRIPTION
## Summary

Refactors `seamless bootstrap-admin` to target instances through the CLI's **profile** system instead of gating on a local `seamless.config.json`.

Previously the command loaded `./seamless.config.json` purely as a presence check — the parsed contents (`services.auth.mode`) were never read — and resolved the target from `SEAMLESS_API_URL`, defaulting to `http://localhost:3000`. That coupled the command to being run from inside a scaffolded project directory.

Now the target instance is resolved from the active profile, consistent with every other instance-facing command (`whoami`, `sessions`, `users`, `org`, …).

### Behavior

Instance URL precedence:
1. `SEAMLESS_API_URL` env override (backward compatible)
2. Active profile's `instanceUrl` — respects `--profile <name>` and `SEAMLESS_PROFILE`
3. `http://localhost:3000` fallback when no profile is configured (preserves the zero-config local flow)

```
seamless bootstrap-admin admin@co.com                 # active profile, else localhost:3000
seamless bootstrap-admin admin@co.com --profile prod  # targets the "prod" profile
SEAMLESS_API_URL=... seamless bootstrap-admin ...      # explicit override still wins
```

### Auth is intentionally unchanged

Bootstrap runs *before any admin user exists*, so it cannot authenticate as the profile's user. It continues to use the shared **bootstrap secret** (Bearer) resolved from `.env` / `auth/.env` / `docker-compose.yml`, or prompts. The profile is used only for *targeting*, not auth.

## Changes

- `src/commands/bootstrapAdmin.ts` — drop the dead `seamless.config.json` gate; add `resolveApiUrl()` and `--profile` parsing (signature is now `(args: string[])`).
- `src/index.ts` — pass `args.slice(1)` through to the command.
- `src/commands/help.ts` — document `--profile` and the new targeting behavior.
- Tests updated (`bootstrapAdmin.test.ts`, `index.test.ts`) covering profile targeting, `--profile`, env override, and localhost fallback.

## Testing

- `vitest run` — 549 passed
- `tsc` typecheck clean
- Coverage thresholds pass; `bootstrapAdmin.ts` at 100%