### PR TITLE
docs: document bootstrap-admin and its profile-based targeting

### DIFF
--- a/.changeset/document-bootstrap-admin.md
+++ b/.changeset/document-bootstrap-admin.md
@@ -1,0 +1,8 @@
+---
+"seamless-cli": patch
+---
+
+Document `bootstrap-admin` in the README: add a "Creating the first admin"
+section covering the command, its profile-based instance targeting (with the
+`SEAMLESS_API_URL` override and `http://localhost:3000` fallback), and the
+bootstrap-secret authentication it uses because it runs before any admin exists.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,28 @@ npm run dev
 
 ---
 
+## Creating the first admin
+
+A fresh instance has no admin yet. `seamless bootstrap-admin` issues the first admin invite:
+
+```bash
+seamless bootstrap-admin admin@example.com                 # active profile's instance
+seamless bootstrap-admin admin@example.com --profile prod  # a specific instance
+seamless bootstrap-admin                                   # prompts for the email
+```
+
+The invited user then completes registration to receive admin access.
+
+**Where it points.** The target instance is resolved from your active profile's `instanceUrl`
+(respecting `--profile` and `SEAMLESS_PROFILE`), so you can bootstrap a remote instance you never
+scaffolded locally. Set `SEAMLESS_API_URL` to override it, or — when no profile is configured — it
+falls back to `http://localhost:3000` for local dev.
+
+**How it authenticates.** Bootstrap runs _before_ any admin exists, so it can't use a login
+session. Instead it uses the instance's shared bootstrap secret, resolved automatically from a
+local `.env`, `auth/.env`, or `docker-compose.yml`, and prompted for if none is found (for example
+when bootstrapping a production instance from a machine without the project checked out).
+
 ## Authenticating against an instance
 
 Beyond scaffolding, the CLI can log in to a Seamless Auth instance (self-hosted, a managed


### PR DESCRIPTION
Follow-up to #66 (profile-based `bootstrap-admin` targeting), which is now merged.

## Summary

The README had no dedicated `bootstrap-admin` documentation. This adds a **"Creating the first admin"** section, placed in the natural flow right after "Running your project" and before "Authenticating against an instance", covering:

- The command and its forms (`admin@example.com`, `--profile prod`, interactive prompt).
- **Where it points** — target instance resolved from the active profile's `instanceUrl` (respecting `--profile` / `SEAMLESS_PROFILE`), with `SEAMLESS_API_URL` override and `http://localhost:3000` fallback.
- **How it authenticates** — the shared bootstrap secret (resolved from `.env` / `auth/.env` / `docker-compose.yml`, else prompted), and *why* it can't use a login session (it runs before any admin exists).

The `--help` menu was already updated in #66, so no code changes are needed here — README + changeset only.