### PR TITLE
fix(verify): build the conformance adapter on Express 5 / Node 24

### DIFF
--- a/.changeset/verify-express5-node24.md
+++ b/.changeset/verify-express5-node24.md
@@ -1,0 +1,5 @@
+---
+"seamless-cli": patch
+---
+
+Fix the conformance harness (`seamless verify --local`) failing to build after the ecosystem moved to Express 5 on Node 24. The verify adapter app pinned `express@^4`, but `@seamless-auth/express` now requires `express@>=5` as a peer, so installing the locally-built SDK tarball aborted with an `ERESOLVE` peer conflict and the Docker build failed. The adapter now depends on `express@^5.1.0` (and `@seamless-auth/express@^0.8.0`), and the verify Docker images are bumped from `node:20` to `node:24` to match the ecosystem's supported runtime.

--- a/verify/adapter-app/Dockerfile
+++ b/verify/adapter-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:24-alpine
 WORKDIR /app
 RUN apk add --no-cache curl
 COPY package.json ./

--- a/verify/adapter-app/package.json
+++ b/verify/adapter-app/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "description": "Minimal adopter backend for the conformance harness — real @seamless-auth/express with a capture transport.",
   "dependencies": {
-    "@seamless-auth/express": "^0.6.0",
+    "@seamless-auth/express": "^0.8.0",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
-    "express": "^4.19.2"
+    "express": "^5.1.0"
   }
 }

--- a/verify/docker-compose.verify.yml
+++ b/verify/docker-compose.verify.yml
@@ -123,7 +123,7 @@ services:
       additional_contexts:
         sdk: ./react-vendor
       dockerfile_inline: |
-        FROM node:20-slim AS builder
+        FROM node:24-slim AS builder
         WORKDIR /app
         COPY package.json package-lock.json ./
         RUN npm ci


### PR DESCRIPTION
## Root cause

Conformance CI (`conformance` workflow → `seamless verify --local`) has been failing on every branch since the ecosystem upgraded to Node 24. The failure is **not** the Node image version — it's an npm peer-dependency conflict.

The verify harness's adapter app (`verify/adapter-app`) pinned `express@^4.19.2`. On the server repo's default branch, `@seamless-auth/express@0.8.0` now declares:

```
peerDependencies: { "express": ">=5.0.0", "@types/express": ">=5.0.0" }
engines:          { "node": ">=24 <25" }
```

In `--local` mode the SDK is built from source and packed into a tarball, then installed over the adapter's deps. Installing `@seamless-auth/express` (peer `express@>=5`) on top of Express 4 aborts with `ERESOLVE`, which fails the `adapter` Docker build, cancels the whole compose build, and makes `seamless verify` exit 1.

From the failing run:
```
npm error ERESOLVE unable to resolve dependency tree
npm error Found: express@4.22.2  (express@"^4.19.2" from the root project)
npm error Could not resolve dependency:
npm error peer express@">=5.0.0" from @seamless-auth/express@0.8.0
target adapter: failed to solve: ... exit code: 1
```

## Fix

- `verify/adapter-app/package.json`: `express@^4.19.2 → ^5.1.0`, `@seamless-auth/express@^0.6.0 → ^0.8.0`.
- Bump the verify Docker images `node:20 → node:24` (adapter Dockerfile + the react service's inline Dockerfile) to match the ecosystem's supported runtime (`node >=24 <25`).

`server.mjs` already uses only Express 5-safe APIs (named `:email` param, no wildcard routes, no removed `app.del`/`req.param`), so no code changes were needed there.

## Validation

Reproduced the exact adapter install locally against freshly-packed SDK tarballs from the server repo:

- **Old config** (`express@^4.19.2`): reproduces the CI `ERESOLVE` failure. ✅ confirmed the root cause.
- **New config** (`express@^5.1.0`): SDK tarballs install cleanly (resolves `express@5.2.1`), the adapter boots (`verify adapter listening`), and `GET /` + the `GET /__captured/:email` route both respond correctly.

Repo test suite: 552 passed. A `patch` changeset is included (the `verify/` dir ships in the package `files`).

Note: this is independent of and separate from the recently added `seamless login --local` mode.