### PR TITLE
feat(login): add --local for OTP delivery via the instance response

### DIFF
--- a/.changeset/login-local-delivery.md
+++ b/.changeset/login-local-delivery.md
@@ -1,0 +1,5 @@
+---
+"seamless-cli": minor
+---
+
+Add `seamless login --local` for self-hosted and local instances. It asks the instance to return the email or phone OTP in the response body instead of sending it, then verifies with that code automatically, so logins work without a real mail or SMS provider. It only runs against local hosts and requires the auth API to run outside production with `ALLOW_UNCREDENTIALED_DELIVERY_SECRETS=true`.

--- a/resources/coverage-badge.svg
+++ b/resources/coverage-badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 99.8%">
-  <title>coverage: 99.8%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 99.7%">
+  <title>coverage: 99.7%</title>
   <linearGradient id="smooth" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -17,7 +17,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="33" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="33" y="14">coverage</text>
-    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">99.8%</text>
-    <text x="88.5" y="14">99.8%</text>
+    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">99.7%</text>
+    <text x="88.5" y="14">99.7%</text>
   </g>
 </svg>

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -15,7 +15,7 @@ USAGE
   seamless bootstrap-admin [email] [--profile <name>]
   seamless verify [--api-only] [--filter=<flow>] [--keep-up]
   seamless profile <list|add|use|remove>
-  seamless login [identifier] [--identifier <email>] [--profile <name>]
+  seamless login [identifier] [--identifier <email>] [--local] [--profile <name>]
   seamless whoami [--profile <name>]
   seamless logout [--all] [--profile <name>]
   seamless sessions [list]
@@ -69,6 +69,12 @@ COMMANDS
     Log in to the active profile's Seamless Auth instance using email OTP.
     Prompts for the identifier (or pass it positionally or with --identifier)
     and the code sent to your inbox, then stores the session in the OS keychain.
+
+    --local
+      • For local instances only. Asks the instance to return the OTP in the
+        response instead of emailing it, and verifies with it automatically.
+      • Requires the auth API to run outside production with
+        ALLOW_UNCREDENTIALED_DELIVERY_SECRETS=true.
 
     --profile <name>
       • Log in against a specific profile instead of the active one

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -365,6 +365,51 @@ describe("runLogin: success", () => {
   });
 });
 
+describe("runLogin: local delivery", () => {
+  beforeEach(() => {
+    upsertProfile({ name: "default", instanceUrl: "http://localhost:5312" });
+  });
+
+  it("auto-fills the OTP from the response without prompting for a code", async () => {
+    const calls = mockRouter({
+      "/login": [
+        () => json({ token: "e1", identifierType: "email", loginMethods: ["email_otp"] }),
+      ],
+      "/otp/generate-login-email-otp": [
+        () => json({ message: "sent", delivery: { kind: "otp_email", token: "ABCDEF" } }),
+      ],
+      "/otp/verify-login-email-otp": [
+        () => json({ token: "a", refreshToken: "r", sub: "user-1", email: "dev@example.com" }),
+      ],
+    });
+    vi.mocked(text).mockResolvedValueOnce("dev@example.com");
+
+    await runLogin(["--local"]);
+
+    // Only the identifier prompt runs; the code is never prompted.
+    expect(vi.mocked(text)).toHaveBeenCalledTimes(1);
+    const stored = await getTokens({ name: "default", instanceUrl: "http://localhost:5312" });
+    expect(stored?.accessToken).toBe("a");
+
+    const generate = calls.find((c) =>
+      c.url.endsWith("/otp/generate-login-email-otp"),
+    )!;
+    expect(
+      (generate.init.headers as Record<string, string>)["x-seamless-auth-delivery-mode"],
+    ).toBe("external");
+  });
+
+  it("rejects --local against a non-local instance", async () => {
+    upsertProfile({ name: "default", instanceUrl: "https://auth.example.com" });
+
+    await expect(runLogin(["--local"])).rejects.toThrow("exit:1");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("--local only works against a local instance"),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
 describe("runLogin: failure handling", () => {
   beforeEach(() => {
     upsertProfile(profile);

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,12 +1,21 @@
 import { intro, outro, text, isCancel, cancel } from "@clack/prompts";
 import kleur from "kleur";
 import { extractFlag } from "../core/args.js";
-import { getActiveProfile, upsertProfile, type Profile } from "../core/config.js";
+import {
+  getActiveProfile,
+  isLocalInstanceUrl,
+  upsertProfile,
+  type Profile,
+} from "../core/config.js";
 import { KeychainUnavailableError, saveTokens } from "../core/keychain.js";
 import { completeLogin, LoginError, type LoginResult } from "../core/loginFlow.js";
 
 export async function runLogin(args: string[]): Promise<void> {
-  const profileFlag = extractFlag(args, "profile");
+  const local = args.includes("--local");
+  const profileFlag = extractFlag(
+    args.filter((a) => a !== "--local"),
+    "profile",
+  );
   const idFlag = extractFlag(profileFlag.rest, "identifier");
 
   const profile = getActiveProfile({ profileFlag: profileFlag.value });
@@ -19,7 +28,19 @@ export async function runLogin(args: string[]): Promise<void> {
     process.exit(1);
   }
 
+  if (local && !isLocalInstanceUrl(profile.instanceUrl)) {
+    console.error(
+      kleur.red(`--local only works against a local instance, not ${profile.instanceUrl}.`),
+    );
+    process.exit(1);
+  }
+
   intro(`Log in to ${kleur.bold(profile.name)} (${profile.instanceUrl})`);
+  if (local) {
+    console.log(
+      kleur.dim("Local delivery on: reading the OTP from the instance response."),
+    );
+  }
 
   let identifier = (idFlag.value ?? idFlag.rest[0])?.trim();
   if (!identifier) {
@@ -41,6 +62,7 @@ export async function runLogin(args: string[]): Promise<void> {
     const result = await completeLogin({
       instanceUrl: profile.instanceUrl,
       identifier,
+      localDelivery: local,
       getCode: async ({ resent, channel }) => {
         const email = channel === "email";
         const answer = await text({
@@ -71,6 +93,9 @@ export async function runLogin(args: string[]): Promise<void> {
             console.log(
               kleur.dim("Your previous code expired, so we sent a new one."),
             );
+            break;
+          case "code_autofilled":
+            console.log(kleur.dim("Read the code from the instance response."));
             break;
           case "incorrect":
             console.log(

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -171,6 +171,17 @@ export function getActiveProfile(
 
 const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
 
+export function isLocalInstanceUrl(input: string): boolean {
+  let url: URL;
+  try {
+    url = new URL((input ?? "").trim());
+  } catch {
+    return false;
+  }
+  const host = url.hostname;
+  return LOCAL_HOSTS.has(host) || host.endsWith(".localhost");
+}
+
 export function normalizeInstanceUrl(input: string): string {
   const trimmed = (input ?? "").trim();
   if (!trimmed) {
@@ -193,8 +204,7 @@ export function normalizeInstanceUrl(input: string): string {
   }
 
   const host = url.hostname;
-  const isLocal = LOCAL_HOSTS.has(host) || host.endsWith(".localhost");
-  if (url.protocol === "http:" && !isLocal) {
+  if (url.protocol === "http:" && !isLocalInstanceUrl(trimmed)) {
     throw new Error(
       `Instance URL must use https for non-local host "${host}".`,
     );

--- a/src/core/loginFlow.test.ts
+++ b/src/core/loginFlow.test.ts
@@ -443,6 +443,83 @@ describe("completeLogin", () => {
     ).rejects.toThrow(/unexpected verification response/);
   });
 
+  it("auto-fills the code from external delivery in local mode", async () => {
+    const calls = mockRouter({
+      "/login": [
+        () => json({ token: "e1", identifierType: "email", loginMethods: ["email_otp"] }),
+      ],
+      "/otp/generate-login-email-otp": [
+        () => json({ message: "sent", delivery: { kind: "otp_email", token: "ABCDEF" } }),
+      ],
+      "/otp/verify-login-email-otp": [() => json({ token: "a", refreshToken: "r" })],
+    });
+
+    let asked = 0;
+    const result = await completeLogin({
+      instanceUrl: INSTANCE,
+      identifier: "dev@example.com",
+      localDelivery: true,
+      getCode: async () => {
+        asked++;
+        return "999999";
+      },
+    });
+
+    expect(asked).toBe(0);
+    expect(result?.tokens.accessToken).toBe("a");
+
+    const generate = calls.find((c) =>
+      c.url.endsWith("/otp/generate-login-email-otp"),
+    )!;
+    expect(
+      (generate.init.headers as Record<string, string>)["x-seamless-auth-delivery-mode"],
+    ).toBe("external");
+
+    const verify = calls.find((c) => c.url.endsWith("/otp/verify-login-email-otp"))!;
+    expect(verify.init.body).toBe(JSON.stringify({ verificationToken: "ABCDEF" }));
+  });
+
+  it("errors in local mode when the instance does not return the code", async () => {
+    mockRouter({
+      "/login": [
+        () => json({ token: "e1", identifierType: "email", loginMethods: ["email_otp"] }),
+      ],
+      "/otp/generate-login-email-otp": [() => json({ message: "sent" })],
+    });
+
+    await expect(
+      completeLogin({
+        instanceUrl: INSTANCE,
+        identifier: "dev@example.com",
+        localDelivery: true,
+        getCode: async () => "123456",
+      }),
+    ).rejects.toThrow(/ALLOW_UNCREDENTIALED_DELIVERY_SECRETS/);
+  });
+
+  it("does not request external delivery when local mode is off", async () => {
+    const calls = mockRouter({
+      "/login": [
+        () => json({ token: "e1", identifierType: "email", loginMethods: ["email_otp"] }),
+      ],
+      "/otp/generate-login-email-otp": [() => json({ message: "sent" })],
+      "/otp/verify-login-email-otp": [() => json({ token: "a", refreshToken: "r" })],
+    });
+
+    await completeLogin({
+      instanceUrl: INSTANCE,
+      identifier: "dev@example.com",
+      getCode: async () => "123456",
+    });
+
+    const generate = calls.find((c) =>
+      c.url.endsWith("/otp/generate-login-email-otp"),
+    )!;
+    expect(
+      (generate.init.headers as Record<string, string>)["x-seamless-auth-delivery-mode"],
+    ).toBeUndefined();
+  });
+
   it("surfaces the rate limiter when verifying a code", async () => {
     mockRouter({
       "/login": [

--- a/src/core/loginFlow.ts
+++ b/src/core/loginFlow.ts
@@ -6,6 +6,8 @@ import type { TokenBundle } from "./keychain.js";
 export const EPHEMERAL_WINDOW_MS = 5 * 60 * 1000;
 export const DEFAULT_MAX_ATTEMPTS = 3;
 
+const EXTERNAL_DELIVERY_HEADER = "x-seamless-auth-delivery-mode";
+
 export type LoginChannel = "email" | "phone";
 
 export class LoginError extends Error {
@@ -18,6 +20,7 @@ export class LoginError extends Error {
 export type LoginEvent =
   | { type: "code_sent"; channel: LoginChannel }
   | { type: "code_resent"; channel: LoginChannel }
+  | { type: "code_autofilled"; channel: LoginChannel }
   | { type: "verifying" }
   | { type: "incorrect"; attemptsLeft: number };
 
@@ -38,6 +41,13 @@ export interface CompleteLoginOptions {
     channel: LoginChannel;
   }) => Promise<string | null>;
   notify?: (event: LoginEvent) => void;
+  /**
+   * Local-only escape hatch. Asks the instance for external delivery so the OTP
+   * comes back in the response body instead of by email/SMS, then verifies with it
+   * automatically. Requires the instance to run outside production with
+   * ALLOW_UNCREDENTIALED_DELIVERY_SECRETS=true, and should be gated to local hosts.
+   */
+  localDelivery?: boolean;
 }
 
 interface StartedLogin {
@@ -46,6 +56,15 @@ interface StartedLogin {
   channel: LoginChannel;
   sub?: string;
   deadline: number;
+}
+
+function deliveryCode(data: Record<string, unknown> | null): string | undefined {
+  const delivery = data?.delivery;
+  if (delivery && typeof delivery === "object") {
+    const token = (delivery as Record<string, unknown>).token;
+    if (typeof token === "string" && token) return token;
+  }
+  return undefined;
 }
 
 function apiMessage(data: unknown): string | undefined {
@@ -133,15 +152,21 @@ async function startLogin(
 async function sendCode(
   instanceUrl: string,
   started: StartedLogin,
-): Promise<void> {
+  localDelivery: boolean,
+): Promise<string | undefined> {
   const path =
     started.channel === "email"
       ? "/otp/generate-login-email-otp"
       : "/otp/generate-login-phone-otp";
 
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${started.ephemeralToken}`,
+  };
+  if (localDelivery) headers[EXTERNAL_DELIVERY_HEADER] = "external";
+
   const res = await request(instanceUrl, joinUrl(instanceUrl, path), {
     method: "GET",
-    headers: { Authorization: `Bearer ${started.ephemeralToken}` },
+    headers,
   });
 
   if (isRateLimited(res)) {
@@ -163,6 +188,8 @@ async function sendCode(
 
   const refreshed = typeof res.data?.token === "string" ? res.data.token : undefined;
   if (refreshed) started.ephemeralToken = refreshed;
+
+  return localDelivery ? deliveryCode(res.data) : undefined;
 }
 
 async function verifyCode(
@@ -192,6 +219,15 @@ export async function completeLogin(
   const now = opts.now ?? (() => Date.now());
   const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
   const notify = opts.notify ?? (() => {});
+  const localDelivery = opts.localDelivery ?? false;
+
+  const requireLocalCode = (code: string | undefined): void => {
+    if (localDelivery && !code) {
+      throw new LoginError(
+        "Local delivery is on, but the instance did not return the code. Start the auth API outside production with ALLOW_UNCREDENTIALED_DELIVERY_SECRETS=true so it returns OTP codes in the response.",
+      );
+    }
+  };
 
   let started = await startLogin(opts.instanceUrl, opts.identifier, now);
   const channel = started.channel;
@@ -202,21 +238,30 @@ export async function completeLogin(
     );
   }
 
-  await sendCode(opts.instanceUrl, started);
+  let autoCode = await sendCode(opts.instanceUrl, started, localDelivery);
   notify({ type: "code_sent", channel });
+  requireLocalCode(autoCode);
 
   let attempt = 0;
   let resent = false;
   while (attempt < maxAttempts) {
-    const code = await opts.getCode({ attempt: attempt + 1, resent, channel });
+    let code: string | null;
+    if (localDelivery && autoCode) {
+      code = autoCode;
+      autoCode = undefined;
+      notify({ type: "code_autofilled", channel });
+    } else {
+      code = await opts.getCode({ attempt: attempt + 1, resent, channel });
+    }
     resent = false;
     if (code === null) return null;
 
     if (now() >= started.deadline) {
       started = await startLogin(opts.instanceUrl, opts.identifier, now);
-      await sendCode(opts.instanceUrl, started);
+      autoCode = await sendCode(opts.instanceUrl, started, localDelivery);
       resent = true;
       notify({ type: "code_resent", channel });
+      requireLocalCode(autoCode);
       continue;
     }
 


### PR DESCRIPTION
## Summary

Local and self-hosted instances without a real mail or SMS provider could not complete OTP login through the CLI: the code was generated and stored only as a hash, never surfaced anywhere. `seamless login --local` closes that gap.

With `--local`, the CLI asks the instance for external delivery (`x-seamless-auth-delivery-mode: external`), reads the OTP back from the response, and verifies with it automatically. No prompt, no real email or SMS needed.

## Behavior

- Gated to local hosts. Running `--local` against a remote instance is rejected with a clear message.
- Requires the auth API to run outside production with `ALLOW_UNCREDENTIALED_DELIVERY_SECRETS=true`. If the instance does not return a code, the CLI fails with an actionable error naming that flag rather than silently prompting.
- Falls back to the normal code prompt if no code is auto-filled (for example on a resend).

## Usage

Server (auth API), non-production:

```
ALLOW_UNCREDENTIALED_DELIVERY_SECRETS=true npm run dev
```

CLI (profile pointed at a local instance):

```
seamless login you@example.com --local
```

## Notes

- Not an API contract change: the external-delivery header and `delivery.token` response field already ship. This is CLI-side only.
- Complementary to the recently merged letter-based email OTP prompt fix (#69), which hardens the manual prompt. `--local` skips the prompt entirely.

## Testing

- `npm run build`: clean
- `npm test`: 588 passed, 4 skipped
- Added unit and command tests covering the external-delivery header, auto-fill, the missing-code error, and the non-local guard.