### PR TITLE
feat(init): enable ALLOW_UNCREDENTIALED_DELIVERY_SECRETS in the scaffolded auth env

### DIFF
--- a/.changeset/scaffold-local-delivery.md
+++ b/.changeset/scaffold-local-delivery.md
@@ -1,0 +1,11 @@
+---
+"seamless-cli": minor
+---
+
+Enable `ALLOW_UNCREDENTIALED_DELIVERY_SECRETS=true` in the scaffolded auth server env.
+
+Companion to the `email_otp` default: with it set, `seamless login --local`
+reads the OTP straight from the auth server's response instead of needing a mail
+provider, so signing in to a freshly scaffolded local stack works end to end.
+It's a dev-only escape hatch — the auth server ignores it under a production
+`NODE_ENV`, and the scaffold runs as development.

--- a/src/generators/docker/docker.test.ts
+++ b/src/generators/docker/docker.test.ts
@@ -97,6 +97,7 @@ describe("buildAuthEnv", () => {
     expect(env.APP_ORIGINS).toBe("http://localhost:3000");
     expect(env.ORIGINS).toBe("http://localhost:5173,http://localhost:5174");
     expect(env.LOGIN_METHODS).toBe("passkey,magic_link,email_otp");
+    expect(env.ALLOW_UNCREDENTIALED_DELIVERY_SECRETS).toBe("true");
     expect(shared.kid).toBe("dev-main");
   });
 

--- a/src/generators/docker/docker.ts
+++ b/src/generators/docker/docker.ts
@@ -263,6 +263,11 @@ export function buildAuthEnv(
   // method the CLI can drive without a browser authenticator.
   env.LOGIN_METHODS = withLoginMethod(env.LOGIN_METHODS, "email_otp");
 
+  // Let `seamless login --local` read the OTP straight from the response instead
+  // of needing a mail provider. Dev-only: the auth server ignores this under a
+  // production NODE_ENV, and the scaffold runs as development.
+  env.ALLOW_UNCREDENTIALED_DELIVERY_SECRETS = "true";
+
   // When the OAuth template collected providers, wire them into the auth server
   // (OAUTH_PROVIDERS, per-provider secret env vars, OAUTH_STATE_SECRET) and enable
   // the oauth login method.


### PR DESCRIPTION
## Summary

Companion to the `email_otp` scaffold default (#75). `buildAuthEnv` now sets `ALLOW_UNCREDENTIALED_DELIVERY_SECRETS=true` on the generated auth server env, so `seamless login --local` reads the OTP straight from the auth server's response instead of needing a mail provider. Combined with `email_otp` in the default login methods, signing in to a freshly scaffolded local stack now works end to end with no manual config.

## Safety

Dev-only escape hatch. The auth server ignores it under a production `NODE_ENV` (`externalDelivery.ts` → `uncredentialedSecretsAllowed()` returns false and logs an error when `NODE_ENV=production`), and the scaffold runs as `development`. Deployers overriding `NODE_ENV=production` get the safe behavior automatically.

## Testing

`tsc`, `eslint`, `build` clean; 588 tests pass. `docker.test.ts` asserts the flag is set in `buildAuthEnv`'s docker-mode output.

Branches off `main` (post-#75); independent of the console-hosting PR (#74).