### PR TITLE
fix(env): quote generated .env values dotenv would misread

### DIFF
--- a/.changeset/fix-env-quoting.md
+++ b/.changeset/fix-env-quoting.md
@@ -1,0 +1,14 @@
+---
+"seamless-cli": patch
+---
+
+Quote generated `.env` values that a dotenv parser would otherwise misread.
+
+`writeEnv` wrote bare `KEY=value`, so a value containing `#`, whitespace, quotes,
+a backslash, or a newline (e.g. a managed `API_SERVICE_TOKEN` or a pasted OAuth
+secret) produced a `.env` that dotenv truncates or mis-parses. Values that need
+it are now double-quoted and escaped, and `parseEnv`/`parseEnvString` unquote on
+read so the CLI round-trips its own output. Simple values (tokens, URLs, hex
+secrets) are still written bare.
+
+Closes #81.

--- a/src/core/env.test.ts
+++ b/src/core/env.test.ts
@@ -50,11 +50,18 @@ describe("parseEnv", () => {
     expect(parseEnv(file)).toEqual({ URL: "https://example.com?a=1&b=2" });
   });
 
-  it("keeps quotes in values as-is (no unquoting)", () => {
+  it("unquotes double-quoted values and unescapes them", () => {
     const file = path.join(tmpDir, ".env");
-    fs.writeFileSync(file, 'FOO="bar baz"\n');
+    fs.writeFileSync(file, 'FOO="bar baz"\nMULTI="a\\nb"\n');
 
-    expect(parseEnv(file)).toEqual({ FOO: '"bar baz"' });
+    expect(parseEnv(file)).toEqual({ FOO: "bar baz", MULTI: "a\nb" });
+  });
+
+  it("treats single-quoted values as literal", () => {
+    const file = path.join(tmpDir, ".env");
+    fs.writeFileSync(file, "FOO='a\\nb'\n");
+
+    expect(parseEnv(file)).toEqual({ FOO: "a\\nb" });
   });
 });
 
@@ -108,6 +115,29 @@ describe("writeEnv", () => {
     const file = path.join(tmpDir, "roundtrip.env");
     const original = { A: "1", B: "two", C: "" };
     writeEnv(file, original);
+
+    expect(parseEnv(file)).toEqual(original);
+  });
+
+  it("quotes values with characters dotenv would misread, and round-trips them", () => {
+    const file = path.join(tmpDir, "special.env");
+    const original = {
+      HASH: "abc#notacomment",
+      SPACED: "with spaces",
+      QUOTED: 'a"b',
+      NEWLINE: "line1\nline2",
+      BACKSLASH: "a\\b",
+      LEADING: " padded ",
+      PLAIN: "simple-token_123",
+    };
+    writeEnv(file, original);
+
+    const raw = fs.readFileSync(file, "utf-8");
+    // The `#` value must be quoted so a dotenv parser doesn't treat it as a comment,
+    // and a simple token must stay bare.
+    expect(raw).toContain('HASH="abc#notacomment"');
+    expect(raw).toContain("PLAIN=simple-token_123");
+    expect(raw).not.toContain("PLAIN=\"");
 
     expect(parseEnv(file)).toEqual(original);
   });

--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -1,45 +1,71 @@
 import fs from "fs";
 
-export function parseEnv(filePath: string): Record<string, string> {
-  const content = fs.readFileSync(filePath, "utf-8");
+// Strips a matching pair of surrounding quotes, mirroring dotenv: double quotes
+// unescape \n, \r, \" and \\; single quotes are literal. Bare values are returned
+// trimmed. This is the inverse of formatValue below, so writeEnv/parseEnv round-trip.
+function unquote(raw: string): string {
+  const v = raw.trim();
+  if (v.length >= 2) {
+    const q = v[0];
+    if ((q === '"' || q === "'") && v[v.length - 1] === q) {
+      const inner = v.slice(1, -1);
+      if (q === "'") return inner;
+      return inner
+        .replace(/\\n/g, "\n")
+        .replace(/\\r/g, "\r")
+        .replace(/\\"/g, '"')
+        .replace(/\\\\/g, "\\");
+    }
+  }
+  return v;
+}
 
-  const lines = content.split("\n");
-
+function parseLines(content: string): Record<string, string> {
   const env: Record<string, string> = {};
 
-  for (const line of lines) {
-    if (!line || line.startsWith("#")) continue;
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
 
-    const [key, ...rest] = line.split("=");
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+
+    const key = line.slice(0, eq).trim();
     if (!key) continue;
 
-    env[key.trim()] = rest.join("=").trim();
+    env[key] = unquote(line.slice(eq + 1));
   }
 
   return env;
 }
 
+export function parseEnv(filePath: string): Record<string, string> {
+  return parseLines(fs.readFileSync(filePath, "utf-8"));
+}
+
 export function parseEnvString(content: string): Record<string, string> {
-  const lines = content.split("\n");
+  return parseLines(content);
+}
 
-  const env: Record<string, string> = {};
+// Double-quotes (and escapes) any value a downstream dotenv parser would otherwise
+// misread: whitespace, `#` (starts a comment), embedded quotes/backslashes, or
+// newlines. Simple values (tokens, URLs, hex secrets) are written bare, unchanged.
+function formatValue(v: string): string {
+  const needsQuoting = v !== "" && (/[\s#"'\\]/.test(v) || v !== v.trim());
+  if (!needsQuoting) return v;
 
-  for (const line of lines) {
-    if (!line || line.startsWith("#")) continue;
+  const escaped = v
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r");
 
-    const [key, ...rest] = line.split("=");
-
-    if (!key) continue;
-
-    env[key.trim()] = rest.join("=").trim();
-  }
-
-  return env;
+  return `"${escaped}"`;
 }
 
 export function writeEnv(filePath: string, env: Record<string, string>) {
   const content = Object.entries(env)
-    .map(([k, v]) => `${k}=${v}`)
+    .map(([k, v]) => `${k}=${formatValue(v)}`)
     .join("\n");
 
   fs.writeFileSync(filePath, content + "\n");


### PR DESCRIPTION
Closes #81.

`writeEnv` wrote bare `KEY=value`, so a value containing `#`, whitespace, quotes, a backslash, or a newline (e.g. a managed `API_SERVICE_TOKEN` or a pasted OAuth secret) produced a `.env` that dotenv truncates or mis-parses.

- `writeEnv` now double-quotes and escapes values that need it; simple values (tokens, URLs, hex secrets) stay bare.
- `parseEnv`/`parseEnvString` unquote on read (dotenv semantics: double quotes unescape `\n`/`\r`/`\"`/`\\`, single quotes literal) so the CLI round-trips its own output.

Tests: added special-character round-trip coverage; tsc/lint clean, 590 tests pass. Branches off `main`.