### PR TITLE
fix(check): make seamless check managed-aware and resilient to partial config

### DIFF
--- a/.changeset/fix-check-managed-aware.md
+++ b/.changeset/fix-check-managed-aware.md
@@ -1,0 +1,17 @@
+---
+"seamless-cli": patch
+---
+
+Make `seamless check` managed-aware and resilient to partial config.
+
+`checkCompose` dereferenced `config.docker.composeFile`, which is `null` for
+managed projects, so `seamless check` crashed with a `TypeError` on any managed
+scaffold. `check` now branches on `services.auth.mode === "managed"`: it validates
+the remote instance's `/health/status` and skips the Docker/compose/container
+checks (which don't apply remotely). It also wraps `JSON.parse` and guards missing
+service entries so a malformed or partial `seamless.config.json` prints a friendly
+message instead of a stack trace. The local console health check is derived from
+`services.admin.mode` (image/source → :5174, api → :3000/console, none/hosted →
+skipped).
+
+Closes #78.

--- a/resources/coverage-badge.svg
+++ b/resources/coverage-badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 99.7%">
-  <title>coverage: 99.7%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 99.5%">
+  <title>coverage: 99.5%</title>
   <linearGradient id="smooth" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -17,7 +17,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="33" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="33" y="14">coverage</text>
-    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">99.7%</text>
-    <text x="88.5" y="14">99.7%</text>
+    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">99.5%</text>
+    <text x="88.5" y="14">99.5%</text>
   </g>
 </svg>

--- a/src/commands/check.test.ts
+++ b/src/commands/check.test.ts
@@ -20,6 +20,7 @@ const CONFIG = {
   services: {
     web: { path: "web" },
     api: { path: "api" },
+    admin: { mode: "image" },
   },
   docker: { composeFile: "docker-compose.yml" },
 };
@@ -85,7 +86,7 @@ describe("runCheck", () => {
     expect(out).toContain("Containers running");
     expect(out).toContain("API is healthy");
     expect(out).toContain("Auth is healthy");
-    expect(out).toContain("Admin is healthy");
+    expect(out).toContain("Console is healthy");
     expect(out).toContain("Check complete.");
   });
 
@@ -123,7 +124,50 @@ describe("runCheck", () => {
     expect(out).toContain("API container not running");
     expect(out).toContain("API returned 503");
     expect(out).toContain("Auth not reachable");
-    expect(out).toContain("Admin not reachable");
+    expect(out).toContain("Console not reachable");
+  });
+
+  it("validates the remote instance for a managed project and skips Docker checks", async () => {
+    const managed = {
+      services: {
+        web: { path: "web" },
+        api: { path: "api" },
+        auth: {
+          mode: "managed",
+          instanceUrl: "https://acme.seamlessauth.com",
+          applicationName: "Acme",
+        },
+      },
+      docker: null,
+    };
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(managed));
+    const seen: string[] = [];
+    vi.mocked(fetch).mockImplementation(async (url: unknown) => {
+      seen.push(String(url));
+      return { ok: true, status: 200 } as Response;
+    });
+
+    await runCheck();
+
+    const out = output();
+    expect(out).toContain("Managed instance: Acme");
+    expect(out).toContain("Auth instance reachable");
+    expect(seen).toContain("https://acme.seamlessauth.com/health/status");
+    // Docker/compose/container checks must not run for managed.
+    expect(execSync).not.toHaveBeenCalled();
+    expect(out).not.toContain("Docker Compose file");
+    expect(seen).not.toContain("http://localhost:5312/health/status");
+  });
+
+  it("reports a friendly error on a malformed config file instead of crashing", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue("{ not json");
+
+    await expect(runCheck()).resolves.toBeUndefined();
+
+    expect(output()).toContain("not valid JSON");
+    expect(execSync).not.toHaveBeenCalled();
   });
 
   it("reports a container check failure when docker ps throws", async () => {

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -15,29 +15,45 @@ export async function runCheck() {
     return;
   }
 
+  let config: any;
+  try {
+    config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+  } catch {
+    console.log("✖ seamless.config.json is not valid JSON");
+    console.log("→ Fix the file, or re-run: seamless init\n");
+    return;
+  }
+
   console.log("✔ Config file found");
 
-  const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
-
   checkStructure(root, config);
-  checkDocker();
-  checkCompose(root, config);
-  checkContainers();
-  await checkHealth();
+
+  // Managed projects run the auth server remotely and ship no compose file, so the
+  // Docker/container checks don't apply — validate the remote instance instead.
+  if (config?.services?.auth?.mode === "managed") {
+    await checkManaged(config);
+  } else {
+    checkDocker();
+    checkCompose(root, config);
+    checkContainers();
+    await checkHealth(config);
+  }
 
   console.log("\nCheck complete.\n");
 }
 
 function checkStructure(root: string, config: any) {
-  const services = config.services;
+  const services = config?.services ?? {};
 
-  if (fs.existsSync(path.join(root, services.web.path))) {
+  const webPath = services.web?.path;
+  if (webPath && fs.existsSync(path.join(root, webPath))) {
     console.log("✔ Web project detected");
   } else {
     console.log("✖ Web project missing");
   }
 
-  if (fs.existsSync(path.join(root, services.api.path))) {
+  const apiPath = services.api?.path;
+  if (apiPath && fs.existsSync(path.join(root, apiPath))) {
     console.log("✔ API project detected");
   } else {
     console.log("✖ API project missing");
@@ -55,9 +71,9 @@ function checkDocker() {
 }
 
 function checkCompose(root: string, config: any) {
-  const composePath = path.join(root, config.docker.composeFile);
+  const composeFile = config?.docker?.composeFile;
 
-  if (fs.existsSync(composePath)) {
+  if (composeFile && fs.existsSync(path.join(root, composeFile))) {
     console.log("✔ Docker Compose file found");
   } else {
     console.log("✖ docker-compose.yml missing");
@@ -79,12 +95,29 @@ function checkContainers() {
   }
 }
 
-async function checkHealth() {
+// The console lives at a different URL per hosting mode: proxied by the API at
+// /console, or a standalone container on 5174. "none"/"hosted" projects have no
+// local console to probe.
+function consoleHealthCheck(config: any): { name: string; url: string } | null {
+  const admin = config?.services?.admin;
+  const mode = admin?.mode;
+  if (mode === "api") {
+    return { name: "Console", url: admin.url || "http://localhost:3000/console" };
+  }
+  if (mode === "image" || mode === "source") {
+    return { name: "Console", url: "http://localhost:5174" };
+  }
+  return null;
+}
+
+async function checkHealth(config: any) {
   const checks = [
     { name: "API", url: "http://localhost:3000/" },
     { name: "Auth", url: "http://localhost:5312/health/status" },
-    { name: "Admin", url: "http://localhost:5174" },
   ];
+
+  const consoleCheck = consoleHealthCheck(config);
+  if (consoleCheck) checks.push(consoleCheck);
 
   for (const check of checks) {
     try {
@@ -98,4 +131,35 @@ async function checkHealth() {
       console.log(`✖ ${check.name} not reachable`);
     }
   }
+}
+
+async function checkManaged(config: any) {
+  const auth = config?.services?.auth ?? {};
+  const instanceUrl: string | undefined = auth.instanceUrl;
+
+  console.log(
+    "✔ Managed instance: " +
+      (auth.applicationName || instanceUrl || "(unknown)"),
+  );
+
+  if (!instanceUrl) {
+    console.log("✖ No managed instance URL recorded in seamless.config.json");
+    return;
+  }
+
+  const healthUrl = `${instanceUrl.replace(/\/$/, "")}/health/status`;
+  try {
+    const res = await fetch(healthUrl);
+    if (res.ok) {
+      console.log("✔ Auth instance reachable");
+    } else {
+      console.log(`✖ Auth instance returned ${res.status}`);
+    }
+  } catch {
+    console.log("✖ Auth instance not reachable");
+  }
+
+  console.log(
+    "→ Managed project: the auth server runs remotely, so Docker and compose checks are skipped.",
+  );
 }


### PR DESCRIPTION
Closes #78.

`checkCompose` dereferenced `config.docker.composeFile`, which is `null` for managed projects (`generators/config/config.ts`), so `seamless check` crashed with a `TypeError` on any managed scaffold.

- Branches on `services.auth.mode === "managed"`: validates the remote instance's `/health/status` and skips the Docker/compose/container checks (which don't apply remotely).
- Wraps `JSON.parse` and guards missing `services.web`/`services.api` so a malformed/partial config prints a friendly message instead of a stack trace.
- Local console health is derived from `services.admin.mode` (image/source -> :5174, api -> :3000/console, none/hosted -> skipped).

Tests: added managed-project and malformed-config cases; tsc/lint clean, 590 tests pass. Branches off `main`.