### PR TITLE
fix(init): harden the managed init flow (fallback UX + recoverable token rotation)

### DIFF
--- a/.changeset/fix-managed-init-hardening.md
+++ b/.changeset/fix-managed-init-hardening.md
@@ -1,0 +1,18 @@
+---
+"seamless-cli": patch
+---
+
+Harden the managed `init` flow.
+
+- **Explicit managed intent no longer silently scaffolds local.** When `--app` is
+  given but there is no usable session (expired or control plane unreachable),
+  `init` now fails with an actionable message instead of quietly scaffolding a
+  self-hosted project and ignoring the flag. Without `--app`, a missing session or
+  an unreachable control plane falls back to local with a clear warning (rather
+  than aborting on transient network errors, as it previously did for non-reauth
+  failures). Closes #79.
+- **Service-token rotation is now recoverable.** Rotation invalidates the app's
+  previous token, so it runs after templates are copied (the likeliest failure
+  point), and every step after it is guarded: if scaffolding fails post-rotation,
+  the freshly issued token is printed so a deployed app can be re-wired instead of
+  left bricked. The same guard covers `integrateExistingProject`. Closes #80.

--- a/resources/coverage-badge.svg
+++ b/resources/coverage-badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 99.7%">
-  <title>coverage: 99.7%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 99.5%">
+  <title>coverage: 99.5%</title>
   <linearGradient id="smooth" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -17,7 +17,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="33" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="33" y="14">coverage</text>
-    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">99.7%</text>
-    <text x="88.5" y="14">99.7%</text>
+    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">99.5%</text>
+    <text x="88.5" y="14">99.5%</text>
   </g>
 </svg>

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -244,9 +244,34 @@ describe("resolveManagedClient", () => {
     expect(runManagedTemplatePrompts).not.toHaveBeenCalled();
   });
 
-  it("rethrows non-reauth errors from the auth client", async () => {
+  it("falls back to local (with a warning) when the control plane is unreachable", async () => {
     vi.mocked(createAuthClient).mockRejectedValue(new Error("boom"));
-    await expect(runCLI()).rejects.toThrow(/boom/);
+    vi.mocked(openTemplateSource).mockResolvedValue(makeSource() as never);
+    vi.mocked(runProjectSetupPrompts).mockResolvedValue({
+      webTemplateId: "web-basic",
+      apiTemplateId: "api-express",
+      authMode: "docker",
+      adminMode: "image",
+      useDocker: true,
+    } as never);
+    vi.mocked(generateDockerCompose).mockResolvedValue({} as never);
+
+    await runCLI();
+
+    expect(runProjectSetupPrompts).toHaveBeenCalled();
+    expect(runManagedTemplatePrompts).not.toHaveBeenCalled();
+    expect(out()).toContain("Could not reach the control plane");
+  });
+
+  it("errors when --app is given but there is no session (no silent local fallback)", async () => {
+    vi.mocked(createAuthClient).mockRejectedValue(
+      new ReauthRequiredError("no session"),
+    );
+
+    await expect(runCLI(undefined, [], { appId: "app-1" })).rejects.toThrow(
+      /--app was given but you are not logged in/,
+    );
+    expect(runProjectSetupPrompts).not.toHaveBeenCalled();
   });
 
   it("skips the auth client entirely with --local", async () => {
@@ -554,6 +579,45 @@ describe("scaffoldManaged", () => {
     expect(confirm).toHaveBeenCalled();
     expect(rotateServiceToken).toHaveBeenCalled();
     expect(printManagedSuccessOutput).toHaveBeenCalled();
+  });
+
+  it("copies templates before rotating the token", async () => {
+    loggedIn();
+    const order: string[] = [];
+    const source = makeSource();
+    source.copyInto = vi.fn(async () => {
+      order.push("copy");
+    }) as never;
+    vi.mocked(openTemplateSource).mockResolvedValue(source as never);
+    vi.mocked(listApplications).mockResolvedValue([app()] as never);
+    vi.mocked(selectApplication).mockResolvedValue(app() as never);
+    vi.mocked(rotateServiceToken).mockImplementation(async () => {
+      order.push("rotate");
+      return "svc-token" as never;
+    });
+
+    await runCLI(undefined, [], { appId: "app-1" });
+
+    // copyInto (the likeliest failure) must run before the destructive rotation.
+    expect(order.indexOf("copy")).toBeLessThan(order.indexOf("rotate"));
+  });
+
+  it("prints the issued token for recovery when a post-rotation step fails", async () => {
+    loggedIn();
+    vi.mocked(listApplications).mockResolvedValue([app()] as never);
+    vi.mocked(selectApplication).mockResolvedValue(app() as never);
+    vi.mocked(rotateServiceToken).mockResolvedValue("svc-token");
+    vi.mocked(applyTemplateEnv).mockImplementation(() => {
+      throw new Error("disk full");
+    });
+
+    await expect(runCLI(undefined, [], { appId: "app-1" })).rejects.toThrow(
+      /disk full/,
+    );
+
+    // The freshly issued (and now-active) token is surfaced so the app can recover.
+    expect(out()).toContain("svc-token");
+    expect(printManagedSuccessOutput).not.toHaveBeenCalled();
   });
 
   it("aborts the scaffold when the developer declines rotation", async () => {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -76,8 +76,25 @@ export async function runCLI(
   }
 
   // A logged-in profile makes the managed path the default; --local forces the
-  // self-hosted stack, and a missing session falls back to it automatically.
-  const client = opts.local ? null : await resolveManagedClient(opts.profileFlag);
+  // self-hosted stack. A missing session or an unreachable control plane falls
+  // back to local — unless managed was requested explicitly (handled below).
+  let client: AuthClient | null = null;
+  let fallbackReason: "no-session" | "unreachable" | null = null;
+  if (!opts.local) {
+    const resolution = await resolveManagedClient(opts.profileFlag);
+    client = resolution.client;
+    if (!client) fallbackReason = resolution.reason;
+  }
+
+  // `--app` is an explicit managed intent. Silently scaffolding local and ignoring
+  // the flag would be surprising, so fail with an actionable message instead.
+  if (!client && opts.appId) {
+    throw new Error(
+      fallbackReason === "unreachable"
+        ? "Could not reach the Seamless control plane to connect a managed instance. Check your connection, or re-run with --local to scaffold a self-hosted stack."
+        : "--app was given but you are not logged in. Run `seamless login` to connect a managed instance, or drop --app to scaffold a local project.",
+    );
+  }
 
   const isEmpty = fs.readdirSync(root).length === 0;
 
@@ -89,20 +106,36 @@ export async function runCLI(
   if (client) {
     await scaffoldManaged(root, projectName, aliases, client, opts);
   } else {
+    if (fallbackReason) {
+      console.log(
+        kleur.yellow(
+          fallbackReason === "unreachable"
+            ? "Could not reach the control plane; scaffolding a local project instead. Use --local to skip this check."
+            : "Not logged in; scaffolding a local project. Run `seamless login` first to connect a managed instance.",
+        ),
+      );
+    }
     await scaffoldLocal(root, projectName, aliases);
   }
 }
 
-// Returns an authenticated control-plane client when a profile is logged in, or
-// null when there is no session (so init drops to the local stack).
+type ManagedResolution =
+  | { client: AuthClient; reason: null }
+  | { client: null; reason: "no-session" | "unreachable" };
+
+// Resolves an authenticated control-plane client. A missing session
+// ("no-session") and an unreachable/errored control plane ("unreachable") both
+// yield a null client so init can fall back to local (or, with --app, error).
 async function resolveManagedClient(
   profileFlag?: string,
-): Promise<AuthClient | null> {
+): Promise<ManagedResolution> {
   try {
-    return await createAuthClient({ profileFlag });
+    return { client: await createAuthClient({ profileFlag }), reason: null };
   } catch (err) {
-    if (err instanceof ReauthRequiredError) return null;
-    throw err;
+    if (err instanceof ReauthRequiredError) {
+      return { client: null, reason: "no-session" };
+    }
+    return { client: null, reason: "unreachable" };
   }
 }
 
@@ -127,56 +160,72 @@ async function scaffoldManaged(
     root,
   );
 
-  // Resolve the target application and its service token before writing files,
-  // so a cancelled selection or an authorization failure leaves nothing behind.
+  // Resolve the target application before writing files, so a cancelled selection
+  // or an authorization failure leaves nothing behind.
   const apps = await listApplications(client);
   const app = await selectApplication(apps, opts.appId);
   if (!app) return;
+
+  // Copy templates before rotating the service token. Rotation invalidates the
+  // app's previous token (see rotateServiceToken), so it runs as late as possible;
+  // copyInto is the likeliest step to fail, so it happens first, before rotation.
+  for (const { entry, dir } of selected) {
+    console.log(`Adding ${entry.label} starter...`);
+    await source.copyInto(entry, dir);
+  }
 
   const serviceToken = await issueServiceToken(client, app);
   if (serviceToken === null) return;
 
   const authServerUrl = normalizeInstanceUrl(app.domain);
 
-  for (const { entry, dir } of selected) {
-    console.log(`Adding ${entry.label} starter...`);
-    await source.copyInto(entry, dir);
+  // Everything past rotation is guarded: if it throws, the freshly issued token is
+  // printed so a deployed app can be re-wired rather than left bricked (the control
+  // plane never re-shows it).
+  try {
+    const ctx: ScaffoldContext = {
+      authServerUrl,
+      apiUrl: API_URL,
+      apiToken: serviceToken,
+      jwksKid: MANAGED_JWKS_KID,
+    };
+
+    for (const { manifest, dir } of selected) {
+      applyTemplateEnv(dir, manifest, ctx);
+    }
+
+    const webEntry = findEntry(source.registry.templates, answers.webTemplateId);
+    const apiEntry = findEntry(source.registry.templates, answers.apiTemplateId);
+
+    generateSeamlessConfig(root, {
+      projectName,
+      webFramework: webEntry.framework,
+      apiFramework: apiEntry.framework,
+      authMode: "managed",
+      adminMode: "image",
+      managed: {
+        instanceUrl: authServerUrl,
+        applicationId: app.id,
+        applicationName: app.name,
+      },
+    });
+
+    printManagedSuccessOutput({
+      projectName,
+      webFramework: webEntry.framework,
+      apiFramework: apiEntry.framework,
+      authServerUrl,
+      appName: app.name,
+    });
+  } catch (err) {
+    console.error(
+      kleur.red(
+        "\nScaffolding failed after a new service token was issued. The token below is valid — set it on your backend to recover:",
+      ),
+    );
+    printManagedValues(authServerUrl, serviceToken);
+    throw err;
   }
-
-  const ctx: ScaffoldContext = {
-    authServerUrl,
-    apiUrl: API_URL,
-    apiToken: serviceToken,
-    jwksKid: MANAGED_JWKS_KID,
-  };
-
-  for (const { manifest, dir } of selected) {
-    applyTemplateEnv(dir, manifest, ctx);
-  }
-
-  const webEntry = findEntry(source.registry.templates, answers.webTemplateId);
-  const apiEntry = findEntry(source.registry.templates, answers.apiTemplateId);
-
-  generateSeamlessConfig(root, {
-    projectName,
-    webFramework: webEntry.framework,
-    apiFramework: apiEntry.framework,
-    authMode: "managed",
-    adminMode: "image",
-    managed: {
-      instanceUrl: authServerUrl,
-      applicationId: app.id,
-      applicationName: app.name,
-    },
-  });
-
-  printManagedSuccessOutput({
-    projectName,
-    webFramework: webEntry.framework,
-    apiFramework: apiEntry.framework,
-    authServerUrl,
-    appName: app.name,
-  });
 }
 
 async function scaffoldLocal(
@@ -298,16 +347,30 @@ async function integrateExistingProject(
   const authServerUrl = normalizeInstanceUrl(app.domain);
   const apiDir = path.join(root, "api");
 
-  if (fs.existsSync(apiDir)) {
-    wireApiEnv(apiDir, authServerUrl, serviceToken);
-    console.log(kleur.green(`Updated ${path.join("api", ".env")}.`));
-    console.log(
-      kleur.dim("  Set your web app's auth server URL to: ") +
-        kleur.cyan(authServerUrl),
-    );
-  } else {
+  if (!fs.existsSync(apiDir)) {
     printManagedValues(authServerUrl, serviceToken);
+    return;
   }
+
+  // The token is already rotated (old one invalidated); if the write fails, print
+  // it so the app can be re-wired by hand rather than left bricked.
+  try {
+    wireApiEnv(apiDir, authServerUrl, serviceToken);
+  } catch (err) {
+    console.error(
+      kleur.red(
+        "\nFailed to write api/.env after issuing a new service token. Set it by hand to recover:",
+      ),
+    );
+    printManagedValues(authServerUrl, serviceToken);
+    throw err;
+  }
+
+  console.log(kleur.green(`Updated ${path.join("api", ".env")}.`));
+  console.log(
+    kleur.dim("  Set your web app's auth server URL to: ") +
+      kleur.cyan(authServerUrl),
+  );
 }
 
 // Merges the managed auth values into an existing api/.env, preserving any keys


### PR DESCRIPTION
Closes #79, closes #80.

### #79 — managed fallback UX
- `--app` is an explicit managed intent, so a missing/unreachable session now **errors** with an actionable message instead of silently scaffolding a local project and ignoring the flag.
- Without `--app`, a missing session **or** an unreachable control plane falls back to local with a clear warning — previously any non-reauth error (DNS/network) aborted `init` entirely. `resolveManagedClient` now returns a discriminated `no-session` / `unreachable` result.

### #80 — recoverable service-token rotation
- Rotation invalidates the app's previous token, so it now runs **after** templates are copied (the likeliest failure point).
- Every step after rotation is wrapped: on failure the freshly issued token is printed via `printManagedValues` so a deployed app can be re-wired rather than left bricked (the control plane never re-shows it). Same guard added to `integrateExistingProject`.

Tests: added fallback-warning, `--app`-without-session, copy-before-rotate, and post-rotation recovery cases; tsc/lint clean, 591 tests pass. Branches off `main`.