### PR TITLE
ci: run build and unit tests on PRs and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build and unit test
+    runs-on: ubuntu-latest
+    env:
+      HUSKY: 0
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Unit tests
+        run: npm test


### PR DESCRIPTION
Closes #88.

No workflow ran the vitest suite — only the Playwright conformance harness runs in CI, and the 590+ unit tests ran only in the bypassable Husky pre-commit hook (`--no-verify`, `HUSKY=0`; release sets `HUSKY: 0`). So a unit-test regression could be published to npm.

Adds a `CI` workflow that runs `npm ci` -> `npm run build` -> `npm test` on every PR and on pushes to `main`, gating merges on a green build + suite.

No changeset (CI-only; doesn't affect the published package).