### PR TITLE
docs: reconcile README and AGENTS.md with actual behavior

### DIFF
--- a/.changeset/docs-reconcile-drift.md
+++ b/.changeset/docs-reconcile-drift.md
@@ -1,0 +1,18 @@
+---
+"seamless-cli": patch
+---
+
+Reconcile documentation with actual behavior.
+
+- README: correct the Node requirement (24, per `.nvmrc`/`engines`, not 18);
+  update `bootstrap-admin` docs to the `--api-url` → `SEAMLESS_API_URL` →
+  `http://localhost:3000` resolution (the removed `--profile` flag and
+  auth-server-profile wording are gone).
+- AGENTS.md: drop the `npm run typecheck`/`lint`/`format:check` commands that
+  don't exist (there is no lint/format tooling yet); note the `--filter=<flow>`
+  (`=` form) for `verify`; list the instance-management commands; remove the stale
+  top-level `templates/` reference (templates live in the `seamless-templates`
+  monorepo).
+- `package.json`: drop the dead `templates` entry from `files`.
+
+Closes #94.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,12 +42,12 @@ guidance may extend them but must not contradict them.
   or docs. Use a comma, parentheses, or a separate sentence.
 
 ### Before declaring work done
-- All code quality checks must pass before you open a PR or call the work done:
-  tests, linting, type checks, and formatting. Run them and report the real
-  output; do not open a PR while any check is failing.
-- Typical commands: `npm run typecheck`, `npm run lint`, `npm run format:check`
-  (or `npm run format`), and `npm test`. Never claim a change works without
-  running them.
+- All code quality checks must pass before you open a PR or call the work done.
+  Run them and report the real output; do not open a PR while any check is failing.
+- Commands: `npm run build` (runs `tsc`, which type-checks) and `npm test`
+  (`vitest run`); `npm run coverage` enforces the coverage thresholds. There is no
+  separate lint/format tooling configured yet. Never claim a change works without
+  running these.
 - Match the surrounding code's style, naming, and comment density.
 
 ## Start Here
@@ -55,7 +55,9 @@ guidance may extend them but must not contradict them.
 - Install dependencies: `npm install`
 - Build (type-check and emit): `npm run build` (`tsc`, output in `dist/`)
 - Run from source: `npm run dev -- <command>` (`tsx`); or after building, `node dist/index.js <command>`
-- Commands: `init [name]`, `check`, `bootstrap-admin <email>`, `verify [flags]`
+- Commands: `init [name]`, `check`, `bootstrap-admin [email]`, `verify [flags]`,
+  and the instance-management commands `profile`, `login`, `whoami`, `logout`,
+  `sessions`, `config`, `users`, `org` (all dispatched from `src/index.ts`)
 
 The entry point is [src/index.ts](src/index.ts), which dispatches to a command module in
 `src/commands/`.
@@ -77,9 +79,12 @@ The entry point is [src/index.ts](src/index.ts), which dispatches to a command m
     [src/core/oauthProviders.ts](src/core/oauthProviders.ts)). The chosen providers are wired into
     the auth server env (`OAUTH_PROVIDERS`, per-provider `*_CLIENT_SECRET`, the `oauth` login
     method) by `buildAuthEnv` in [src/generators/docker/docker.ts](src/generators/docker/docker.ts).
-- **check** health-checks a running stack.
-- **bootstrap-admin** mints the first admin invite.
+- **check** health-checks a running stack (local or managed).
+- **bootstrap-admin** mints the first admin invite against the app API.
 - **verify** ([src/commands/verify.ts](src/commands/verify.ts)) runs the conformance harness (below).
+- **instance management** — `profile` (targets), `login`/`logout`/`whoami`,
+  `sessions`, `config` (system config + OAuth providers), `users`, and `org` all
+  talk to a running instance and are authenticated by the stored session.
 
 ## The verify harness
 
@@ -102,7 +107,7 @@ Modes and sibling repos:
 - The sibling repos are resolved relative to this repo, overridable with `SEAMLESS_API_DIR`,
   `SEAMLESS_SERVER_DIR`, `SEAMLESS_REACT_SDK_DIR` (the React SDK), and `SEAMLESS_REACT_DIR` (the
   `react-vite` web template, defaulting to `../seamless-templates/templates/web/react-vite`).
-- Useful flags: `--api-only`, `--no-react`, `--filter <grep>`, `--keep-up`.
+- Useful flags: `--api-only`, `--no-react`, `--filter=<flow>` (the `=` form; a space-separated `--filter <flow>` is not parsed), `--keep-up`.
 
 ## Important Folders
 
@@ -112,7 +117,9 @@ Modes and sibling repos:
 - [src/prompts](src/prompts): interactive setup prompts (`@clack/prompts`)
 - [src/utils](src/utils): repo and env-file helpers
 - [verify](verify): the conformance harness (shipped with the package)
-- [templates](templates): static template assets
+
+Templates are not in this repo — they live in the `seamless-templates` monorepo
+(`SEAMLESS_TEMPLATES_REPO`) and are fetched at scaffold time.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -163,17 +163,17 @@ npm run dev
 A fresh instance has no admin yet. `seamless bootstrap-admin` issues the first admin invite:
 
 ```bash
-seamless bootstrap-admin admin@example.com                 # active profile's instance
-seamless bootstrap-admin admin@example.com --profile prod  # a specific instance
-seamless bootstrap-admin                                   # prompts for the email
+seamless bootstrap-admin admin@example.com                          # local app API (default)
+seamless bootstrap-admin admin@example.com --api-url https://api...  # a specific app API
+seamless bootstrap-admin                                            # prompts for the email
 ```
 
 The invited user then completes registration to receive admin access.
 
-**Where it points.** The target instance is resolved from your active profile's `instanceUrl`
-(respecting `--profile` and `SEAMLESS_PROFILE`), so you can bootstrap a remote instance you never
-scaffolded locally. Set `SEAMLESS_API_URL` to override it, or — when no profile is configured — it
-falls back to `http://localhost:3000` for local dev.
+**Where it points.** The bootstrap invite route is served by your app API (the SeamlessAuth
+server adapter), not the auth server directly, so the target is resolved independently of any
+login profile: `--api-url` wins, then `SEAMLESS_API_URL`, then the local default
+`http://localhost:3000`.
 
 **How it authenticates.** Bootstrap runs _before_ any admin exists, so it can't use a login
 session. Instead it uses the instance's shared bootstrap secret, resolved automatically from a
@@ -367,7 +367,7 @@ Seamless CLI exists to make this setup fast and repeatable.
 
 ## Requirements
 
-- Node.js 18 or newer
+- Node.js 24 (see `.nvmrc`; the package `engines` requires `>=24 <25`)
 - npm or pnpm
 - Docker (optional)
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "main": "dist/index.js",
   "files": [
     "dist",
-    "templates",
     "verify",
     "README.md",
     "LICENSE"


### PR DESCRIPTION
Closes #94.

- **README**: Node requirement corrected to 24 (per `.nvmrc`/`engines >=24 <25`, was "18 or newer"); `bootstrap-admin` docs updated to the `--api-url` -> `SEAMLESS_API_URL` -> `http://localhost:3000` resolution (removes the deleted `--profile` flag and the auth-server-profile wording).
- **AGENTS.md**: removes `npm run typecheck`/`lint`/`format:check` (no such scripts / no lint-format tooling configured); documents `verify --filter=<flow>` (the `=` form; space form isn't parsed); lists the instance-management commands (`profile`, `login`, `whoami`, `logout`, `sessions`, `config`, `users`, `org`); removes the stale top-level `templates/` reference.
- **package.json**: drops the dead `templates` entry from `files`.

Docs/config only. Branches off `main`.