### PR TITLE
fix(verify): set FRONTEND_URL in the conformance stack and dump logs on failure

### DIFF
--- a/.changeset/fix-conformance-frontend-url.md
+++ b/.changeset/fix-conformance-frontend-url.md
@@ -1,0 +1,14 @@
+---
+"seamless-cli": patch
+---
+
+Fix the conformance stack and surface container logs on failure.
+
+auth-api 0.3.0 requires `FRONTEND_URL` at startup (a required system config), which
+the verify compose never set — so the auth-api container exited on boot and every
+`conformance` run (here and in sibling repos calling the reusable workflow) aborted
+with a bare "docker failed" before any layer ran. `verify/docker-compose.verify.yml`
+now sets `FRONTEND_URL`, and `seamless verify` dumps recent container logs on a
+setup failure so a container that exits on startup is diagnosable instead of hidden.
+
+Closes #107.

--- a/src/commands/verify.test.ts
+++ b/src/commands/verify.test.ts
@@ -356,6 +356,15 @@ describe("runVerify — conformance failures (caught, exits 1)", () => {
     const printed = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
     expect(printed).toMatch(/Verify aborted/);
     expect(printed).toMatch(/No conformance layers ran/);
+    // On a stack failure the recent container logs are dumped so the real cause
+    // (e.g. a container that exited on startup) isn't hidden behind "docker failed".
+    expect(printed).toMatch(/Recent container logs/);
+    expect(runCommand).toHaveBeenCalledWith(
+      "docker",
+      expect.arrayContaining(["logs"]),
+      expect.anything(),
+      expect.anything(),
+    );
   });
 });
 

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -477,6 +477,17 @@ export async function runVerify(args: string[] = []): Promise<void> {
     failed = true;
     setupError = err as Error;
     console.log(kleur.red(`\n✖ Conformance failed: ${setupError.message}\n`));
+    // A container that exits on startup surfaces only as "docker failed" — dump the
+    // recent stack logs before teardown so the real cause is visible (in CI too).
+    console.log(kleur.dim("→ Recent container logs:\n"));
+    await compose(
+      baseEnv,
+      "--profile",
+      "react",
+      "logs",
+      "--tail",
+      "80",
+    ).catch(() => undefined);
   } finally {
     if (opts.keepUp) {
       console.log(kleur.dim("Stack left running (--keep-up). Tear down with:"));

--- a/verify/docker-compose.verify.yml
+++ b/verify/docker-compose.verify.yml
@@ -51,6 +51,10 @@ services:
       DEFAULT_ROLES: user
       AVAILABLE_ROLES: user,admin
       LOGIN_METHODS: passkey,magic_link,email_otp,phone_otp,oauth
+      # Required system config as of auth-api 0.3.0: the base URL for emailed
+      # magic links. Without it (and with a fresh DB, so system_config isn't seeded)
+      # the server exits at startup. The browser-visible web app runs on 5173.
+      FRONTEND_URL: http://localhost:5173
       DB_LOGGING: 'false'
       ACCESS_TOKEN_TTL: 15m
       REFRESH_TOKEN_TTL: 1h


### PR DESCRIPTION
Closes #107.

## Root cause
The `conformance` workflow fails on every PR here **and in the sibling repos** that call the reusable `verify-conformance.yml`. auth-api 0.3.0 now requires `FRONTEND_URL` at startup (a required system config seeded from env on a fresh DB); the shared `verify/docker-compose.verify.yml` never set it, so the auth-api container exited on boot:

```
[server] ERROR - Failed to start server: Missing required system config "frontend_url".
auth-api-1 exited with code 1
```

The stack then aborted (`dependency failed to start` → `Conformance failed: docker failed`) and the harness tore down **without** printing the container log, so the cause was invisible.

## Fix
- Add `FRONTEND_URL: http://localhost:5173` to the auth-api service in the verify compose.
- `seamless verify` now dumps recent `docker compose logs` on a setup failure, so a container that exits on startup is diagnosable (in CI too) instead of a bare "docker failed".

## Verification
Reproduced locally (built auth-api from source, brought it up with the verify env): before, exit 1 with the frontend_url error; after, auth-api boots healthy (`Server online.` / `Serving admin dashboard at /console`). tsc/lint clean, full suite (591 + updated verify test) green.

Because sibling repos check out seamless-cli's reusable workflow at its default branch, **merging this to `main` fixes conformance across the ecosystem**; for CLI PRs it takes effect once they include this commit (rebase after merge).