### PR TITLE
fix(verify): use a >=32-char dev service token so the adapter starts

### DIFF
--- a/.changeset/fix-verify-cookie-secret-length.md
+++ b/.changeset/fix-verify-cookie-secret-length.md
@@ -1,0 +1,13 @@
+---
+"seamless-cli": patch
+---
+
+Fix the conformance adapter crash: the dev service token was too short.
+
+`seamless verify` defaulted `API_SERVICE_TOKEN` to a 24-char constant, which the
+adapter reuses as its cookie secret; a newer `@seamless-auth/express` rejects a
+cookieSecret shorter than 32, so the adapter container exited and conformance
+failed after the stack came up. The dev service token and bootstrap secret
+defaults are now >=32 characters.
+
+Closes #109.

--- a/src/commands/verify.test.ts
+++ b/src/commands/verify.test.ts
@@ -134,6 +134,19 @@ describe("runVerify — published (default) mode", () => {
     expect(tails[tails.length - 1]).toEqual(["--profile", "react", "down", "-v"]);
     expect(exitSpy).not.toHaveBeenCalled();
   });
+
+  it("defaults the service token to >=32 chars (the adapter cookie-secret minimum)", async () => {
+    delete process.env.API_SERVICE_TOKEN;
+    await runVerify(["--api-only"]);
+
+    const dockerUp = vi
+      .mocked(runCommand)
+      .mock.calls.find(
+        (c) => c[0] === "docker" && (c[1] as string[]).includes("up"),
+      );
+    const env = dockerUp?.[3] as NodeJS.ProcessEnv;
+    expect((env.API_SERVICE_TOKEN ?? "").length).toBeGreaterThanOrEqual(32);
+  });
 });
 
 describe("runVerify — flag parsing", () => {

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -391,14 +391,20 @@ export async function runVerify(args: string[] = []): Promise<void> {
   const webTemplates = opts.react ? resolveWebTemplates() : [];
   const packageVersions = collectPackageVersions(opts, apiDir, webTemplates);
 
-  const serviceToken = process.env.API_SERVICE_TOKEN ?? "verify-dev-service-token";
+  // Dev-only fixed secrets (deterministic across runs). They must be at least 32
+  // characters: the adapter reuses the service token as its cookie secret, and
+  // @seamless-auth/express rejects a cookieSecret shorter than 32.
+  const serviceToken =
+    process.env.API_SERVICE_TOKEN ??
+    "verify-dev-service-token-not-a-real-secret";
   const baseEnv: NodeJS.ProcessEnv = {
     ...process.env,
     SEAMLESS_API_DIR: apiDir,
     API_SERVICE_TOKEN: serviceToken,
     JWKS_KID: process.env.JWKS_KID ?? "dev-main",
     SEAMLESS_BOOTSTRAP_SECRET:
-      process.env.SEAMLESS_BOOTSTRAP_SECRET ?? "verify-dev-bootstrap-secret",
+      process.env.SEAMLESS_BOOTSTRAP_SECRET ??
+      "verify-dev-bootstrap-secret-not-a-real-secret",
     // consumed by the harness
     SEAMLESS_API_SERVICE_TOKEN: serviceToken,
     SEAMLESS_API_URL: "http://localhost:5312",


### PR DESCRIPTION
Closes #109. Follow-up to #108.

With the FRONTEND_URL fix merged, the auth-api boots and conformance gets far enough to start the **adapter**, which then exits — now visible thanks to #108's log dump:

```
adapter-1 | Error: cookieSecret must be at least 32 characters...
dependency failed to start: container seamless-verify-adapter-1 exited (1)
```

The adapter reuses `API_SERVICE_TOKEN` as its `COOKIE_SIGNING_KEY`, and `seamless verify` defaulted the token to `"verify-dev-service-token"` (24 chars); a newer `@seamless-auth/express` rejects a cookie secret shorter than 32.

**Fix:** default the dev service token and bootstrap secret to >=32-char constants. Added a test asserting the default token is >=32 chars. tsc/lint clean, 24 verify tests pass.

Merging to `main` advances conformance for the ecosystem; open CLI PRs pick it up on their next rebase.