### PR TITLE
fix(verify): POST the adapter OTP/magic-link generate routes

### DIFF
--- a/.changeset/fix-conformance-adapter-otp-post.md
+++ b/.changeset/fix-conformance-adapter-otp-post.md
@@ -1,0 +1,13 @@
+---
+"seamless-cli": patch
+---
+
+Fix the conformance adapter flows to match the SDK's POST OTP/magic-link routes.
+
+`@seamless-auth/express` now serves OTP generate routes (and `/magic-link`) over
+POST, but the harness adapter flows still called them with GET, so every adapter
+spec failed at `generate-email-otp -> 404` once the stack came up. The adapter
+flows now POST `/auth/otp/generate-email-otp`, `/auth/otp/generate-login-email-otp`,
+and `/auth/magic-link`.
+
+Closes #111.

--- a/verify/harness/lib/adapterFlows.ts
+++ b/verify/harness/lib/adapterFlows.ts
@@ -16,7 +16,7 @@ export async function registerAndVerifyEmail(ctx: APIRequestContext, email: stri
   let res = await ctx.post('/auth/registration/register', { data: { email } });
   expect(res.ok(), `register -> ${res.status()}`).toBeTruthy();
 
-  res = await ctx.get('/auth/otp/generate-email-otp');
+  res = await ctx.post('/auth/otp/generate-email-otp');
   expect(res.ok(), `generate-email-otp -> ${res.status()}`).toBeTruthy();
 
   const code = await readCapturedCode(ctx, email);
@@ -28,7 +28,7 @@ export async function loginViaEmailOtp(ctx: APIRequestContext, email: string): P
   let res = await ctx.post('/auth/login', { data: { identifier: email } });
   expect(res.ok(), `login -> ${res.status()}`).toBeTruthy();
 
-  res = await ctx.get('/auth/otp/generate-login-email-otp');
+  res = await ctx.post('/auth/otp/generate-login-email-otp');
   expect(res.ok(), `generate-login-email-otp -> ${res.status()}`).toBeTruthy();
 
   const code = await readCapturedCode(ctx, email);
@@ -40,7 +40,7 @@ export async function loginViaMagicLink(ctx: APIRequestContext, email: string): 
   let res = await ctx.post('/auth/login', { data: { identifier: email } });
   expect(res.ok(), `login -> ${res.status()}`).toBeTruthy();
 
-  res = await ctx.get('/auth/magic-link');
+  res = await ctx.post('/auth/magic-link');
   expect(res.ok(), `magic-link request -> ${res.status()}`).toBeTruthy();
   const token = await readCapturedCode(ctx, email);
 


### PR DESCRIPTION
Closes #111. Third and (expected) final conformance blocker.

With #108 (FRONTEND_URL) and #110 (>=32-char token) merged, the stack now boots and the matrix reaches the flows. The **adapter** layer then failed — register/emailOtp/magicLink/session all at `generate-email-otp -> 404`.

**Root cause:** `@seamless-auth/express` intentionally moved OTP generate routes to POST (`seamless-auth-server` `827b4ed fix(express)!: serve OTP generate routes over POST (#109)`) and serves `/magic-link` as POST, but the harness adapter flows still used GET. The harness was correctly catching a stale contract — this updates it to the adapter's actual interface.

- `adapterFlows.ts`: GET → POST for `/auth/otp/generate-email-otp`, `/auth/otp/generate-login-email-otp`, `/auth/magic-link`.
- The direct-API layer (`flows.ts`) stays GET, matching auth-api, which still serves generate as GET.

**Follow-up (sibling repos, flagged in #111):** auth-api serves OTP generate as GET while the SDK is POST — worth reconciling on one method so the API and adapter layers aren't split.

Validated the reasoning against both repos' route tables (auth-api `otp.routes.ts` = GET; express `createServer.ts` = POST). This is harness code (Playwright), validated by the conformance run on this PR.