### PR TITLE
fix(verify): disable auth rate limits in the conformance stack

### DIFF
--- a/.changeset/fix-conformance-disable-rate-limits.md
+++ b/.changeset/fix-conformance-disable-rate-limits.md
@@ -1,0 +1,14 @@
+---
+"seamless-cli": patch
+---
+
+Disable auth rate limits in the conformance stack.
+
+The conformance suite drives many OTP/registration/magic-link flows from a single
+IP and trips auth-api's dedicated per-IP limiters (which `RATE_LIMIT` doesn't
+tune), so the adapter layer failed with 429s once the stack came up. The verify
+compose now sets `DISABLE_AUTH_RATE_LIMITS=true` on the auth-api service — a
+dev-only flag (ignored under `NODE_ENV=production`) added in seamless-auth-api.
+
+Requires seamless-auth-api with `DISABLE_AUTH_RATE_LIMITS` support; conformance
+builds it from source, so no release is needed.

--- a/verify/docker-compose.verify.yml
+++ b/verify/docker-compose.verify.yml
@@ -60,6 +60,10 @@ services:
       REFRESH_TOKEN_TTL: 1h
       RATE_LIMIT: '100000'
       DELAY_AFTER: '100000'
+      # The dedicated per-IP OTP/magic-link/registration/OAuth limiters are not
+      # tuned by RATE_LIMIT; the suite drives many flows from one IP and would trip
+      # them. This dev-only flag skips them (ignored under NODE_ENV=production).
+      DISABLE_AUTH_RATE_LIMITS: 'true'
       RPID: localhost
       ORIGINS: http://localhost:5173,http://localhost:3000
       DB_HOST: postgres


### PR DESCRIPTION
Depends on fells-code/seamless-auth-api#99.

The conformance suite drives many OTP/registration/magic-link flows from a single IP and trips auth-api's **dedicated** per-IP limiters (OTP 10/15min, etc.), which `RATE_LIMIT` does not tune. After the stack comes up, the adapter layer fails with 429s (`register -> 429`, `verify-email-otp -> 429`).

Sets `DISABLE_AUTH_RATE_LIMITS: 'true'` on the auth-api service in the verify compose. That flag is added in seamless-auth-api#99 and is dev-only (refused under `NODE_ENV=production`). Conformance runs `verify --local` (builds auth-api from source), so this takes effect once #99 is merged — no release needed.

**Merge order:** seamless-auth-api#99 first, then this. Together with #112 (adapter OTP→POST), this should turn the conformance matrix fully green.