### PR TITLE
chore: bump seamless auth-api, admin dashboard, and templates versions

### DIFF
--- a/resources/coverage-badge.svg
+++ b/resources/coverage-badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 99.5%">
-  <title>coverage: 99.5%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 99.4%">
+  <title>coverage: 99.4%</title>
   <linearGradient id="smooth" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -17,7 +17,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="33" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="33" y="14">coverage</text>
-    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">99.5%</text>
-    <text x="88.5" y="14">99.5%</text>
+    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">99.4%</text>
+    <text x="88.5" y="14">99.4%</text>
   </g>
 </svg>

--- a/src/core/images.ts
+++ b/src/core/images.ts
@@ -1,10 +1,10 @@
 export const POSTGRES_IMAGE = "postgres:17";
 
-export const SEAMLESS_AUTH_API_VERSION = "v0.3.0";
+export const SEAMLESS_AUTH_API_VERSION = "v0.4.0";
 
 export const SEAMLESS_AUTH_API_IMAGE = `ghcr.io/fells-code/seamless-auth-api:${SEAMLESS_AUTH_API_VERSION}`;
 
-export const SEAMLESS_AUTH_ADMIN_DASHBOARD_VERSION = "v0.1.0";
+export const SEAMLESS_AUTH_ADMIN_DASHBOARD_VERSION = "v0.3.0";
 
 export const SEAMLESS_AUTH_ADMIN_DASHBOARD_IMAGE = `ghcr.io/fells-code/seamless-auth-admin-dashboard:${SEAMLESS_AUTH_ADMIN_DASHBOARD_VERSION}`;
 
@@ -13,4 +13,4 @@ export const SEAMLESS_AUTH_ADMIN_DASHBOARD_IMAGE = `ghcr.io/fells-code/seamless-
 // SEAMLESS_TEMPLATES_REF, or point at a local checkout with SEAMLESS_TEMPLATES_DIR.
 export const SEAMLESS_TEMPLATES_REPO = "fells-code/seamless-templates";
 
-export const SEAMLESS_TEMPLATES_REF = "v0.3.0";
+export const SEAMLESS_TEMPLATES_REF = "v0.4.0";


### PR DESCRIPTION
Bumps the pinned Seamless component versions the CLI pulls to their latest published tags.

| Constant | Old | New |
|---|---|---|
| \`SEAMLESS_AUTH_API_VERSION\` | v0.3.0 | v0.4.0 |
| \`SEAMLESS_AUTH_ADMIN_DASHBOARD_VERSION\` | v0.1.0 | v0.3.0 |
| \`SEAMLESS_TEMPLATES_REF\` | v0.3.0 | v0.4.0 |

All three derive from single constants in \`src/core/images.ts\`, so this flows through to the generated Docker image tags, the \`.env.example\` fetch, and the templates the CLI scaffolds from.

Full test suite passes (606 tests).