### PR TITLE
chore: add changeset for seamless version bumps

### DIFF
--- a/.changeset/bump-seamless-versions.md
+++ b/.changeset/bump-seamless-versions.md
@@ -1,0 +1,7 @@
+---
+"seamless-cli": patch
+---
+
+Bump the pinned Seamless component versions the CLI pulls to their latest
+published tags: auth-api `v0.3.0` → `v0.4.0`, admin dashboard `v0.1.0` →
+`v0.3.0`, and the templates ref `v0.3.0` → `v0.4.0`.


### PR DESCRIPTION
Follow-up to #115, which merged the version bumps without a changeset.

Adds a `patch` changeset for `seamless-cli` covering the pinned component bumps:
- auth-api `v0.3.0` → `v0.4.0`
- admin dashboard `v0.1.0` → `v0.3.0`
- templates ref `v0.3.0` → `v0.4.0`

So the next `version packages` run records these in the changelog.