### PR TITLE
fix(verify): bump released-smoke adapter to @seamless-auth/express ^0.9.0

### DIFF
--- a/.changeset/released-smoke-express-0-9.md
+++ b/.changeset/released-smoke-express-0-9.md
@@ -1,0 +1,10 @@
+---
+"seamless-cli": patch
+---
+
+Fix the released conformance smoke (`released-smoke`): bump the harness adapter's
+`@seamless-auth/express` pin from `^0.8.0` to `^0.9.0`. The published 0.8.0 still
+served the OTP/magic-link generate routes as `GET`, while the harness flows and
+`@seamless-auth/react` 0.5.0 both `POST` them, so every adapter (and downstream
+react) flow failed with `generate-email-otp -> 404`. 0.9.0 serves them as `POST`,
+matching what the source (`--local`) conformance already builds.

--- a/verify/adapter-app/package.json
+++ b/verify/adapter-app/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Minimal adopter backend for the conformance harness — real @seamless-auth/express with a capture transport.",
   "dependencies": {
-    "@seamless-auth/express": "^0.8.0",
+    "@seamless-auth/express": "^0.9.0",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "express": "^5.1.0"


### PR DESCRIPTION
## What

Bumps the conformance harness adapter's `@seamless-auth/express` pin from `^0.8.0` to `^0.9.0` in `verify/adapter-app/package.json`.

## Why

`released-smoke` (the daily `local:false` run) has been red since **July 11**. The failure was **not** a Node version issue — the "Node 20 deprecated" lines in the logs are the standard GitHub Actions runner notice.

Two things were going on:

1. **The auth-api startup crash** seen in the last run (`docker failed`, container exited on boot) was the missing-`FRONTEND_URL` crash — **already fixed in `main`** (the FRONTEND_URL / rate-limit / POST-routes commits all merged ~7h *after* the last observed failing run).

2. **The remaining failure** is this one: the pin resolved published `@seamless-auth/express@0.8.0`, which still serves the OTP/magic-link `generate-*` routes as **GET**. The harness adapter flows and `@seamless-auth/react` 0.5.0 both **POST** those routes → every adapter (and downstream react) flow failed with `generate-email-otp -> 404`. `0.9.0` serves them as **POST**.

The `^0.8.0` pin only affects `local:false` (released) runs — in `local:true` conformance the source 0.9.0 tarball is installed over it. So this bump simply brings released-smoke in line with what the CLI conformance workflow already builds.

## Verification

Reproduced the full matrix locally. Before: `✖ API / adapter` (4× `generate-email-otp -> 404`). After: `✔ API / adapter` on express 0.9.0, across two runs (source and released).

The browser (react) layer can't be exercised reliably on the arm64 dev machine — it fails identically even with the source SDKs that pass in CI — so final green confirmation should come from a `released-smoke` `workflow_dispatch` run.