### PR TITLE
feat: sign seamless login in to the Seamless portal

### DIFF
--- a/.changeset/portal-login.md
+++ b/.changeset/portal-login.md
@@ -1,0 +1,15 @@
+---
+"seamless-cli": minor
+---
+
+`seamless login` now signs in to the Seamless portal instead of the active profile's instance, and
+no longer needs a profile to exist first. The portal session is stored beside the profile map in
+`config.json` and is the only session `init` uses to connect a managed application, so a session
+for a local or self-hosted instance no longer sends its token to the control plane.
+
+Instance login moves to `seamless profile login [name]`, which signs in without changing the active
+profile. `seamless login --profile <name>` keeps working for one more minor version and prints a
+pointer to the new command. `whoami` and `logout` default to the portal session and take
+`--profile <name>` to target an instance.
+
+Set `SEAMLESS_PORTAL_AUTH_URL` to point the portal login at a different auth host.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,9 +82,15 @@ The entry point is [src/index.ts](src/index.ts), which dispatches to a command m
 - **check** health-checks a running stack (local or managed).
 - **bootstrap-admin** mints the first admin invite against the app API.
 - **verify** ([src/commands/verify.ts](src/commands/verify.ts)) runs the conformance harness (below).
-- **instance management** — `profile` (targets), `login`/`logout`/`whoami`,
-  `sessions`, `config` (system config + OAuth providers), `users`, and `org` all
-  talk to a running instance and are authenticated by the stored session.
+- **instance management** — `profile` (targets, plus `profile login`),
+  `logout`/`whoami`, `sessions`, `config` (system config + OAuth providers),
+  `users`, and `org` all talk to a running instance and are authenticated by the
+  stored session.
+- **portal** — `login` signs in to the Seamless portal, a separate account from
+  any instance profile. Its session lives beside the profile map in
+  `config.json` and is the only one `init` uses to connect a managed
+  application ([src/core/authClient.ts](src/core/authClient.ts) exposes
+  `createPortalClient` for it).
 
 ## The verify harness
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,12 @@ You’ll be guided through a short setup process where you can choose:
 
 ## Connecting to a managed instance
 
-If you are logged in to a managed Seamless Auth account (see
-[Authenticating against an instance](#authenticating-against-an-instance)), `init` connects the new
-project to your managed instance instead of scaffolding a local auth server. This is the default
-whenever a profile has an active session.
+If you are signed in to the Seamless portal (`seamless login`), `init` connects the new project to
+your managed instance instead of scaffolding a local auth server. This is the default whenever a
+portal session exists.
 
 ```bash
-seamless login          # once, against your managed profile
+seamless login          # once, no profile needed
 seamless init my-app    # scaffolds web + api wired to the managed instance
 ```
 
@@ -64,9 +63,12 @@ own source is never overwritten.
 
 Escape hatches:
 
-- `seamless init --local` forces the self-hosted flow below, even when logged in.
-- With no active session, `init` uses the self-hosted flow automatically.
-- `SEAMLESS_PORTAL_API_URL` overrides the control-plane host (defaults to the managed service).
+- `seamless init --local` forces the self-hosted flow below, even when signed in.
+- With no portal session, `init` uses the self-hosted flow automatically. A profile session is not
+  consulted: signing in to an auth instance you administer says nothing about whether you have a
+  managed account.
+- `SEAMLESS_PORTAL_API_URL` overrides the control-plane host (defaults to the managed service), and
+  `SEAMLESS_PORTAL_AUTH_URL` overrides the portal auth instance the login targets.
 
 ---
 
@@ -186,6 +188,18 @@ Beyond scaffolding, the CLI can log in to a Seamless Auth instance (self-hosted,
 tenant, or local dev) and call its authenticated and admin endpoints from the terminal. It talks
 to the instance directly over Bearer and JSON, so no server or contract changes are required.
 
+### Two kinds of account
+
+The CLI signs in to two different things, and they are separate accounts even when they share an
+email address:
+
+| | Command | What it is | What it authorizes |
+| --- | --- | --- | --- |
+| Portal | `seamless login` | Your Seamless customer account on the managed control plane. There is one. | Listing managed applications and connecting a project to one (`init`) |
+| Instance | `seamless profile login <name>` | An admin account inside a specific auth instance's own user pool. There are many. | `users`, `config`, `org`, `sessions` against that instance |
+
+The portal session is stored beside the profile map in `config.json`, not inside it.
+
 ### Profiles
 
 The CLI targets instances through named profiles stored at `~/.config/seamless/config.json`
@@ -208,14 +222,24 @@ other than `localhost`, `127.0.0.1`, or `::1`.
 
 ### Logging in
 
-Login uses email OTP: you paste the code from your inbox, so nothing needs to be delivered to the
-CLI and no service token is required.
+Both logins use email OTP: you paste the code from your inbox, so nothing needs to be delivered to
+the CLI and no service token is required.
 
 ```bash
+# The portal, for managed work. Needs no profile.
 seamless login                       # prompts for the identifier, then the code
 seamless login you@example.com       # identifier as an argument
-seamless login --identifier you@example.com --profile prod
+
+# An auth instance, for admin work against it.
+seamless profile login prod          # defaults to the active profile
+seamless profile login prod --identifier you@example.com
 ```
+
+`seamless profile login` does not change which profile is active, so a one-off command against
+another instance leaves your default alone.
+
+`seamless login --profile <name>` still performs an instance login for one more minor version and
+prints a pointer to `seamless profile login`.
 
 The command honors the instance's advertised login methods, caps local retries so it does not trip
 the OTP rate limiter, and refreshes the code automatically if the five minute window lapses.
@@ -223,8 +247,10 @@ the OTP rate limiter, and refreshes the code automatically if the five minute wi
 ### Identity and sessions
 
 ```bash
-seamless whoami                 # sub, email, roles, active profile, and instance URL
-seamless logout                 # end the current session and clear local tokens
+seamless whoami                 # sub, email, roles, and instance URL for your portal session
+seamless whoami --profile prod  # the same for an instance session
+seamless logout                 # end the portal session and clear local tokens
+seamless logout --profile prod  # end an instance session instead
 seamless logout --all           # revoke every session for the user, then clear local tokens
 
 seamless sessions               # list active sessions (current one marked)

--- a/resources/coverage-badge.svg
+++ b/resources/coverage-badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 99.4%">
-  <title>coverage: 99.4%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 99.3%">
+  <title>coverage: 99.3%</title>
   <linearGradient id="smooth" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -17,7 +17,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="33" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="33" y="14">coverage</text>
-    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">99.4%</text>
-    <text x="88.5" y="14">99.4%</text>
+    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">99.3%</text>
+    <text x="88.5" y="14">99.3%</text>
   </g>
 </svg>

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -14,8 +14,8 @@ USAGE
   seamless check
   seamless bootstrap-admin [email] [--api-url <url>]
   seamless verify [--api-only] [--filter=<flow>] [--keep-up]
-  seamless profile <list|add|use|remove>
-  seamless login [identifier] [--identifier <email>] [--local] [--profile <name>]
+  seamless profile <list|add|use|remove|login>
+  seamless login [identifier] [--identifier <email>] [--local]
   seamless whoami [--profile <name>]
   seamless logout [--all] [--profile <name>]
   seamless sessions [list]
@@ -46,9 +46,11 @@ COMMANDS
         GitLab) and wires the ones you configure into the auth server
       • Run an unknown flag to see the available examples
 
-  profile <list|add|use|remove>
+  profile <list|add|use|remove|login>
     Manage the Seamless Auth instances the CLI targets, stored as named
     profiles in ~/.config/seamless/config.json (respects XDG_CONFIG_HOME).
+    A profile is an instance you administer, which is a different account from
+    your portal login: it lives in that instance's own user pool.
 
     profile list
       • Show configured profiles; the active one is marked with *
@@ -62,30 +64,35 @@ COMMANDS
     profile remove <name>
       • Delete a profile
 
+    profile login [name] [identifier] [--identifier <email>] [--local]
+      • Log in to that instance so users, config, org, and sessions can run
+      • Defaults to the active profile, and does not change which one is active
+
     The active profile can also be chosen per command with --profile <name> or
     the SEAMLESS_PROFILE environment variable.
 
   login [identifier]
-    Log in to the active profile's Seamless Auth instance using email OTP.
-    Prompts for the identifier (or pass it positionally or with --identifier)
-    and the code sent to your inbox, then stores the session in the OS keychain.
+    Sign in to the Seamless portal, the managed control plane. This is the
+    account that authorizes connecting a project to a managed application, and
+    it needs no profile. Prompts for the identifier (or pass it positionally or
+    with --identifier) and the emailed code, then stores the session in the OS
+    keychain. Use seamless profile login to sign in to an auth instance.
 
     --local
-      • For local instances only. Asks the instance to return the OTP in the
+      • For a local portal only. Asks the instance to return the OTP in the
         response instead of emailing it, and verifies with it automatically.
       • Requires the auth API to run outside production with
         ALLOW_UNCREDENTIALED_DELIVERY_SECRETS=true.
-
-    --profile <name>
-      • Log in against a specific profile instead of the active one
-      • Also selectable with the SEAMLESS_PROFILE environment variable
+      • Point SEAMLESS_PORTAL_AUTH_URL at a local instance to develop against it.
 
   whoami
-    Show the identity behind the active profile's session (sub, email, roles),
-    alongside the profile name and instance URL. Fails cleanly if not logged in.
+    Show the identity behind your portal session (sub, email, roles), alongside
+    the instance URL. Pass --profile <name> to report an instance session
+    instead. Fails cleanly if not logged in.
 
   logout [--all]
-    End the current session on the instance and clear the local keychain tokens.
+    End your portal session and clear the local keychain tokens. Pass
+    --profile <name> to log out of an instance instead.
     --all revokes every session for the user before clearing local tokens.
 
   sessions [list]

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -19,7 +19,7 @@ import {
   assertCliSupports,
   openTemplateSource,
 } from "../core/templates.js";
-import { createAuthClient, ReauthRequiredError } from "../core/authClient.js";
+import { createPortalClient, ReauthRequiredError } from "../core/authClient.js";
 import { listApplications, rotateServiceToken } from "../core/portal.js";
 import { selectApplication } from "../prompts/appSelect.js";
 import { parseEnv, writeEnv } from "../core/env.js";
@@ -74,7 +74,7 @@ vi.mock("../core/templates.js", () => ({
 }));
 vi.mock("../core/authClient.js", () => {
   class ReauthRequiredError extends Error {}
-  return { createAuthClient: vi.fn(), ReauthRequiredError };
+  return { createPortalClient: vi.fn(), ReauthRequiredError };
 });
 vi.mock("../core/portal.js", () => ({
   listApplications: vi.fn(),
@@ -197,7 +197,7 @@ describe("runCLI directory handling", () => {
 
   it("creates the project directory and logs it", async () => {
     // New named project: does not exist, then scaffold local runs.
-    vi.mocked(createAuthClient).mockRejectedValue(
+    vi.mocked(createPortalClient).mockRejectedValue(
       new ReauthRequiredError("no session"),
     );
     vi.mocked(openTemplateSource).mockResolvedValue(makeSource() as never);
@@ -223,7 +223,7 @@ describe("runCLI directory handling", () => {
 
 describe("resolveManagedClient", () => {
   it("falls back to the local stack when no session exists", async () => {
-    vi.mocked(createAuthClient).mockRejectedValue(
+    vi.mocked(createPortalClient).mockRejectedValue(
       new ReauthRequiredError("no session"),
     );
     vi.mocked(openTemplateSource).mockResolvedValue(makeSource() as never);
@@ -245,7 +245,7 @@ describe("resolveManagedClient", () => {
   });
 
   it("falls back to local (with a warning) when the control plane is unreachable", async () => {
-    vi.mocked(createAuthClient).mockRejectedValue(new Error("boom"));
+    vi.mocked(createPortalClient).mockRejectedValue(new Error("boom"));
     vi.mocked(openTemplateSource).mockResolvedValue(makeSource() as never);
     vi.mocked(runProjectSetupPrompts).mockResolvedValue({
       webTemplateId: "web-basic",
@@ -264,7 +264,7 @@ describe("resolveManagedClient", () => {
   });
 
   it("errors when --app is given but there is no session (no silent local fallback)", async () => {
-    vi.mocked(createAuthClient).mockRejectedValue(
+    vi.mocked(createPortalClient).mockRejectedValue(
       new ReauthRequiredError("no session"),
     );
 
@@ -288,14 +288,14 @@ describe("resolveManagedClient", () => {
 
     await runCLI(undefined, [], { local: true });
 
-    expect(createAuthClient).not.toHaveBeenCalled();
+    expect(createPortalClient).not.toHaveBeenCalled();
     expect(runProjectSetupPrompts).toHaveBeenCalled();
   });
 });
 
 describe("scaffoldLocal", () => {
   beforeEach(() => {
-    vi.mocked(createAuthClient).mockRejectedValue(
+    vi.mocked(createPortalClient).mockRejectedValue(
       new ReauthRequiredError("no session"),
     );
     vi.mocked(openTemplateSource).mockResolvedValue(makeSource() as never);
@@ -418,7 +418,7 @@ describe("scaffoldLocal", () => {
 
 describe("template alias resolution", () => {
   beforeEach(() => {
-    vi.mocked(createAuthClient).mockRejectedValue(
+    vi.mocked(createPortalClient).mockRejectedValue(
       new ReauthRequiredError("no session"),
     );
     vi.mocked(openTemplateSource).mockResolvedValue(makeSource() as never);
@@ -497,7 +497,7 @@ describe("template alias resolution", () => {
 
 describe("findEntry", () => {
   it("throws when a selected template id is not in the registry", async () => {
-    vi.mocked(createAuthClient).mockRejectedValue(
+    vi.mocked(createPortalClient).mockRejectedValue(
       new ReauthRequiredError("no session"),
     );
     vi.mocked(openTemplateSource).mockResolvedValue(makeSource() as never);
@@ -518,7 +518,7 @@ describe("findEntry", () => {
 
 describe("scaffoldManaged", () => {
   function loggedIn() {
-    vi.mocked(createAuthClient).mockResolvedValue({
+    vi.mocked(createPortalClient).mockResolvedValue({
       profile: { name: "default", instanceUrl: "https://auth" },
     } as never);
     vi.mocked(openTemplateSource).mockResolvedValue(makeSource() as never);
@@ -667,7 +667,7 @@ describe("integrateExistingProject", () => {
   });
 
   it("prints login guidance when there is no session", async () => {
-    vi.mocked(createAuthClient).mockRejectedValue(
+    vi.mocked(createPortalClient).mockRejectedValue(
       new ReauthRequiredError("no session"),
     );
 
@@ -678,7 +678,7 @@ describe("integrateExistingProject", () => {
   });
 
   it("updates api/.env when an api directory exists", async () => {
-    vi.mocked(createAuthClient).mockResolvedValue({
+    vi.mocked(createPortalClient).mockResolvedValue({
       profile: { name: "default", instanceUrl: "https://auth" },
     } as never);
     vi.mocked(listApplications).mockResolvedValue([app()] as never);
@@ -704,7 +704,7 @@ describe("integrateExistingProject", () => {
   });
 
   it("preserves existing api/.env values when the file is present", async () => {
-    vi.mocked(createAuthClient).mockResolvedValue({
+    vi.mocked(createPortalClient).mockResolvedValue({
       profile: { name: "default", instanceUrl: "https://auth" },
     } as never);
     vi.mocked(listApplications).mockResolvedValue([app()] as never);
@@ -729,7 +729,7 @@ describe("integrateExistingProject", () => {
   });
 
   it("prints the managed values to paste when there is no api directory", async () => {
-    vi.mocked(createAuthClient).mockResolvedValue({
+    vi.mocked(createPortalClient).mockResolvedValue({
       profile: { name: "default", instanceUrl: "https://auth" },
     } as never);
     vi.mocked(listApplications).mockResolvedValue([app()] as never);
@@ -745,7 +745,7 @@ describe("integrateExistingProject", () => {
   });
 
   it("returns early when no application is selected", async () => {
-    vi.mocked(createAuthClient).mockResolvedValue({
+    vi.mocked(createPortalClient).mockResolvedValue({
       profile: { name: "default", instanceUrl: "https://auth" },
     } as never);
     vi.mocked(listApplications).mockResolvedValue([] as never);
@@ -758,7 +758,7 @@ describe("integrateExistingProject", () => {
   });
 
   it("returns early when token issuance is declined", async () => {
-    vi.mocked(createAuthClient).mockResolvedValue({
+    vi.mocked(createPortalClient).mockResolvedValue({
       profile: { name: "default", instanceUrl: "https://auth" },
     } as never);
     const existing = app({ hasServiceToken: true });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -27,7 +27,7 @@ import {
 import { runOAuthSetupPrompts } from "../prompts/oauthSetup.js";
 import type { CollectedOAuthProvider } from "../core/oauthProviders.js";
 import {
-  createAuthClient,
+  createPortalClient,
   ReauthRequiredError,
   type AuthClient,
 } from "../core/authClient.js";
@@ -62,6 +62,17 @@ export async function runCLI(
 ) {
   const cwd = process.cwd();
 
+  // Managed connect now reads the portal session, so a profile no longer selects
+  // anything here. Warn rather than silently ignoring it.
+  // TODO(#125): drop the flag one minor version after release.
+  if (opts.profileFlag) {
+    console.log(
+      kleur.yellow(
+        "init no longer takes --profile; managed connect uses your portal session. Run: seamless login",
+      ),
+    );
+  }
+
   let root = cwd;
 
   if (projectName) {
@@ -75,13 +86,13 @@ export async function runCLI(
     console.log(`Creating project in ${root}`);
   }
 
-  // A logged-in profile makes the managed path the default; --local forces the
+  // A portal session makes the managed path the default; --local forces the
   // self-hosted stack. A missing session or an unreachable control plane falls
-  // back to local — unless managed was requested explicitly (handled below).
+  // back to local, unless managed was requested explicitly (handled below).
   let client: AuthClient | null = null;
   let fallbackReason: "no-session" | "unreachable" | null = null;
   if (!opts.local) {
-    const resolution = await resolveManagedClient(opts.profileFlag);
+    const resolution = await resolveManagedClient();
     client = resolution.client;
     if (!client) fallbackReason = resolution.reason;
   }
@@ -123,14 +134,15 @@ type ManagedResolution =
   | { client: AuthClient; reason: null }
   | { client: null; reason: "no-session" | "unreachable" };
 
-// Resolves an authenticated control-plane client. A missing session
-// ("no-session") and an unreachable/errored control plane ("unreachable") both
-// yield a null client so init can fall back to local (or, with --app, error).
-async function resolveManagedClient(
-  profileFlag?: string,
-): Promise<ManagedResolution> {
+// Resolves an authenticated control-plane client from the portal session. A
+// missing session ("no-session") and an unreachable/errored control plane
+// ("unreachable") both yield a null client so init can fall back to local (or,
+// with --app, error). Instance profiles are deliberately not consulted: a session
+// for an auth instance the developer administers says nothing about whether they
+// have a managed account, and sending its token to the control plane would fail.
+async function resolveManagedClient(): Promise<ManagedResolution> {
   try {
-    return { client: await createAuthClient({ profileFlag }), reason: null };
+    return { client: await createPortalClient(), reason: null };
   } catch (err) {
     if (err instanceof ReauthRequiredError) {
       return { client: null, reason: "no-session" };

--- a/src/commands/instanceLogin.test.ts
+++ b/src/commands/instanceLogin.test.ts
@@ -1,0 +1,260 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@clack/prompts", () => {
+  const CANCEL = Symbol("cancel");
+  return {
+    CANCEL,
+    intro: vi.fn(),
+    outro: vi.fn(),
+    text: vi.fn(),
+    isCancel: (value: unknown) => value === CANCEL,
+    cancel: vi.fn(),
+  };
+});
+
+import { CANCEL, cancel, outro, text } from "@clack/prompts";
+import { loadConfig, upsertProfile } from "../core/config.js";
+import {
+  KeychainUnavailableError,
+  getTokens,
+  setBackendForTesting,
+  type KeychainBackend,
+} from "../core/keychain.js";
+import { loginToInstance } from "./instanceLogin.js";
+
+function fakeBackend(): KeychainBackend {
+  const store = new Map<string, string>();
+  return {
+    get: (account) => store.get(account) ?? null,
+    set: (account, secret) => {
+      store.set(account, secret);
+    },
+    delete: (account) => store.delete(account),
+  };
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function mockOtpRoutes(verify: () => Response): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => {
+      if (url.endsWith("/login")) {
+        return json({
+          token: "e1",
+          identifierType: "email",
+          loginMethods: ["email_otp"],
+        });
+      }
+      if (url.endsWith("/otp/generate-login-email-otp")) {
+        return json({ message: "sent" });
+      }
+      return verify();
+    }),
+  );
+}
+
+const profile = { name: "default", instanceUrl: "https://auth.example.com" };
+
+let configHome: string;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  configHome = fs.mkdtempSync(path.join(os.tmpdir(), "seamless-instance-login-"));
+  process.env.XDG_CONFIG_HOME = configHome;
+  delete process.env.SEAMLESS_PROFILE;
+  delete process.env.SEAMLESS_REFRESH_TOKEN;
+
+  setBackendForTesting(fakeBackend());
+
+  vi.mocked(text).mockReset();
+  vi.mocked(outro).mockClear();
+  vi.mocked(cancel).mockClear();
+
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new Error(`exit:${code}`);
+  }) as never);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  setBackendForTesting(null);
+  fs.rmSync(configHome, { recursive: true, force: true });
+  delete process.env.XDG_CONFIG_HOME;
+});
+
+describe("loginToInstance", () => {
+  it("errors and exits 1 when no profile is configured", async () => {
+    await expect(loginToInstance()).rejects.toThrow("exit:1");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("No active profile is configured."),
+    );
+    expect(
+      logSpy.mock.calls.some((c) =>
+        (c[0] as string).includes("seamless profile add"),
+      ),
+    ).toBe(true);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("rejects --local against a non-local instance", async () => {
+    upsertProfile(profile);
+
+    await expect(loginToInstance({ local: true })).rejects.toThrow("exit:1");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("--local only works against a local instance"),
+    );
+  });
+
+  it("saves tokens and updates the profile on success", async () => {
+    upsertProfile(profile);
+    mockOtpRoutes(() =>
+      json({
+        token: "access-1",
+        refreshToken: "refresh-1",
+        sub: "user-1",
+        email: "dev@example.com",
+      }),
+    );
+    vi.mocked(text).mockResolvedValueOnce("123456");
+
+    await loginToInstance({ identifier: "dev@example.com" });
+
+    const stored = await getTokens(profile);
+    expect(stored?.refreshToken).toBe("refresh-1");
+
+    const updated = loadConfig().profiles.default;
+    expect(updated.sub).toBe("user-1");
+    expect(updated.email).toBe("dev@example.com");
+
+    // Signing in to an instance must not create a portal session.
+    expect(loadConfig().portal).toBeUndefined();
+    expect(outro).toHaveBeenCalledWith(
+      expect.stringContaining("Logged in to default as dev@example.com."),
+    );
+  });
+
+  it("targets a named profile without switching the active one", async () => {
+    upsertProfile(profile);
+    const other = { name: "other", instanceUrl: "https://other.example.com" };
+    upsertProfile(other);
+    mockOtpRoutes(() => json({ token: "a", refreshToken: "r" }));
+    vi.mocked(text).mockResolvedValueOnce("123456");
+
+    await loginToInstance({
+      profileName: "other",
+      identifier: "dev@example.com",
+    });
+
+    expect(await getTokens(other)).not.toBeNull();
+    expect(await getTokens(profile)).toBeNull();
+    expect(loadConfig().activeProfile).toBe("default");
+  });
+
+  it("announces local delivery and reads the code from the response", async () => {
+    const local = { name: "default", instanceUrl: "http://localhost:5312" };
+    upsertProfile(local);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.endsWith("/login")) {
+          return json({
+            token: "e1",
+            identifierType: "email",
+            loginMethods: ["email_otp"],
+          });
+        }
+        if (url.endsWith("/otp/generate-login-email-otp")) {
+          return json({ message: "sent", delivery: { token: "ABCDEF" } });
+        }
+        return json({ token: "a", refreshToken: "r" });
+      }),
+    );
+
+    await loginToInstance({ identifier: "dev@example.com", local: true });
+
+    expect(vi.mocked(text)).not.toHaveBeenCalled();
+    expect(
+      logSpy.mock.calls.some((c) =>
+        (c[0] as string).includes("Local delivery on"),
+      ),
+    ).toBe(true);
+  });
+
+  it("cancels when a prompt is cancelled", async () => {
+    upsertProfile(profile);
+    vi.mocked(text).mockResolvedValueOnce(CANCEL);
+
+    await loginToInstance();
+
+    expect(cancel).toHaveBeenCalledWith("Cancelled.");
+  });
+
+  it("exits 1 with a red message on a LoginError", async () => {
+    upsertProfile(profile);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+
+    await expect(
+      loginToInstance({ identifier: "dev@example.com" }),
+    ).rejects.toThrow("exit:1");
+    expect(outro).toHaveBeenCalledWith(
+      expect.stringContaining("Could not reach"),
+    );
+  });
+
+  it("exits 1 when the keychain is unavailable", async () => {
+    upsertProfile(profile);
+    mockOtpRoutes(() => json({ token: "a", refreshToken: "r" }));
+    vi.mocked(text).mockResolvedValueOnce("123456");
+    setBackendForTesting({
+      get: () => null,
+      set: () => {
+        throw new KeychainUnavailableError();
+      },
+      delete: () => false,
+    });
+
+    await expect(
+      loginToInstance({ identifier: "dev@example.com" }),
+    ).rejects.toThrow("exit:1");
+    expect(outro).toHaveBeenCalledWith(
+      expect.stringContaining("No OS keychain is available"),
+    );
+  });
+
+  it("propagates unexpected errors", async () => {
+    upsertProfile(profile);
+    mockOtpRoutes(() => json({ token: "a", refreshToken: "r" }));
+    vi.mocked(text).mockResolvedValueOnce("123456");
+    setBackendForTesting({
+      get: () => null,
+      set: () => {
+        throw new Error("disk on fire");
+      },
+      delete: () => false,
+    });
+
+    await expect(
+      loginToInstance({ identifier: "dev@example.com" }),
+    ).rejects.toThrow("disk on fire");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/instanceLogin.ts
+++ b/src/commands/instanceLogin.ts
@@ -1,0 +1,85 @@
+import { intro, outro, cancel } from "@clack/prompts";
+import kleur from "kleur";
+
+import {
+  getActiveProfile,
+  isLocalInstanceUrl,
+  upsertProfile,
+} from "../core/config.js";
+import { KeychainUnavailableError, saveTokens } from "../core/keychain.js";
+import { promptLogin } from "../core/interactiveLogin.js";
+import { LoginError } from "../core/loginFlow.js";
+
+export interface InstanceLoginOptions {
+  profileName?: string;
+  identifier?: string;
+  local?: boolean;
+}
+
+// Signs in to an auth instance a developer administers, which is what authorizes
+// the /admin routes behind `users`, `config`, `org`, and `sessions`. Distinct
+// from the portal session: that account lives on the control plane, this one
+// lives in the instance's own user pool.
+export async function loginToInstance(
+  opts: InstanceLoginOptions = {},
+): Promise<void> {
+  const profile = getActiveProfile({ profileFlag: opts.profileName });
+  if (!profile) {
+    console.error(kleur.red("No active profile is configured."));
+    console.log(
+      "Add one with: " +
+        kleur.cyan("seamless profile add <name> --instance-url <url>"),
+    );
+    process.exit(1);
+  }
+
+  if (opts.local && !isLocalInstanceUrl(profile.instanceUrl)) {
+    console.error(
+      kleur.red(
+        `--local only works against a local instance, not ${profile.instanceUrl}.`,
+      ),
+    );
+    process.exit(1);
+  }
+
+  intro(`Log in to ${kleur.bold(profile.name)} (${profile.instanceUrl})`);
+  if (opts.local) {
+    console.log(
+      kleur.dim("Local delivery on: reading the OTP from the instance response."),
+    );
+  }
+
+  try {
+    const result = await promptLogin({
+      instanceUrl: profile.instanceUrl,
+      identifier: opts.identifier,
+      knownEmail: profile.email,
+      localDelivery: opts.local,
+    });
+
+    if (!result) {
+      cancel("Cancelled.");
+      return;
+    }
+
+    await saveTokens(profile, result.tokens);
+    upsertProfile({
+      ...profile,
+      sub: result.identity.sub ?? profile.sub,
+      email: result.identity.email ?? profile.email,
+      identifierType: result.identity.identifierType,
+    });
+
+    outro(
+      kleur.green(
+        `Logged in to ${profile.name} as ${result.identity.email ?? result.identifier}.`,
+      ),
+    );
+  } catch (err) {
+    if (err instanceof LoginError || err instanceof KeychainUnavailableError) {
+      outro(kleur.red(err.message));
+      process.exit(1);
+    }
+    throw err;
+  }
+}

--- a/src/commands/login.test.ts
+++ b/src/commands/login.test.ts
@@ -16,7 +16,7 @@ vi.mock("@clack/prompts", () => {
 });
 
 import { CANCEL, cancel, intro, outro, text } from "@clack/prompts";
-import { loadConfig, upsertProfile } from "../core/config.js";
+import { loadConfig, savePortalSession, upsertProfile } from "../core/config.js";
 import {
   KeychainUnavailableError,
   getTokens,
@@ -69,6 +69,9 @@ function mockRouter(routes: Record<string, Array<() => Response>>): Call[] {
 
 const profile = { name: "default", instanceUrl: "https://auth.example.com" };
 
+const PORTAL_URL = "https://portal.example.com";
+const portalTarget = { name: "__portal__", instanceUrl: PORTAL_URL };
+
 let configHome: string;
 let logSpy: ReturnType<typeof vi.spyOn>;
 let errorSpy: ReturnType<typeof vi.spyOn>;
@@ -79,6 +82,7 @@ beforeEach(() => {
   process.env.XDG_CONFIG_HOME = configHome;
   delete process.env.SEAMLESS_PROFILE;
   delete process.env.SEAMLESS_REFRESH_TOKEN;
+  process.env.SEAMLESS_PORTAL_AUTH_URL = PORTAL_URL;
 
   setBackendForTesting(fakeBackend());
 
@@ -100,28 +104,35 @@ afterEach(() => {
   setBackendForTesting(null);
   fs.rmSync(configHome, { recursive: true, force: true });
   delete process.env.XDG_CONFIG_HOME;
+  delete process.env.SEAMLESS_PORTAL_AUTH_URL;
 });
 
 function logs(): string[] {
   return logSpy.mock.calls.map((c) => c[0] as string);
 }
 
-describe("runLogin: no active profile", () => {
-  it("errors and exits 1", async () => {
-    await expect(runLogin([])).rejects.toThrow("exit:1");
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("No active profile is configured."),
-    );
-    expect(logs().some((l) => l.includes("seamless profile add"))).toBe(true);
-    expect(exitSpy).toHaveBeenCalledWith(1);
+describe("runLogin: no configuration", () => {
+  it("signs in to the portal without a profile", async () => {
+    const calls = mockRouter({
+      "/login": [
+        () => json({ token: "e1", identifierType: "email", loginMethods: ["email_otp"] }),
+      ],
+      "/otp/generate-login-email-otp": [() => json({ message: "sent" })],
+      "/otp/verify-login-email-otp": [
+        () => json({ token: "a", refreshToken: "r", email: "dev@example.com" }),
+      ],
+    });
+    vi.mocked(text).mockResolvedValueOnce("dev@example.com").mockResolvedValueOnce("123456");
+
+    await runLogin([]);
+
+    expect(loadConfig().profiles).toEqual({});
+    expect(calls.every((c) => c.url.startsWith(PORTAL_URL))).toBe(true);
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 });
 
 describe("runLogin: identifier prompt", () => {
-  beforeEach(() => {
-    upsertProfile(profile);
-  });
-
   it("cancels when the identifier prompt is cancelled", async () => {
     vi.mocked(text).mockResolvedValueOnce(CANCEL);
 
@@ -164,12 +175,31 @@ describe("runLogin: identifier prompt", () => {
   });
 });
 
-describe("runLogin: success", () => {
-  beforeEach(() => {
-    upsertProfile(profile);
-  });
+describe("runLogin: prefill", () => {
+  it("offers the previous portal email as the default identifier", async () => {
+    savePortalSession({ instanceUrl: PORTAL_URL, email: "dev@example.com" });
+    mockRouter({
+      "/login": [
+        () => json({ token: "e1", identifierType: "email", loginMethods: ["email_otp"] }),
+      ],
+      "/otp/generate-login-email-otp": [() => json({ message: "sent" })],
+      "/otp/verify-login-email-otp": [() => json({ token: "a", refreshToken: "r" })],
+    });
+    vi.mocked(text).mockResolvedValueOnce("dev@example.com").mockResolvedValueOnce("123456");
 
-  it("logs in, saves tokens, and updates the profile", async () => {
+    await runLogin([]);
+
+    const idCall = vi.mocked(text).mock.calls[0][0] as {
+      initialValue: string;
+      placeholder: string;
+    };
+    expect(idCall.initialValue).toBe("dev@example.com");
+    expect(idCall.placeholder).toBe("dev@example.com");
+  });
+});
+
+describe("runLogin: success", () => {
+  it("logs in, saves tokens, and records the portal session", async () => {
     mockRouter({
       "/login": [
         () => json({ token: "e1", identifierType: "email", loginMethods: ["email_otp"] }),
@@ -189,16 +219,23 @@ describe("runLogin: success", () => {
 
     await runLogin([]);
 
-    const stored = await getTokens(profile);
+    const stored = await getTokens(portalTarget);
     expect(stored?.accessToken).toBe("access-1");
     expect(stored?.refreshToken).toBe("refresh-1");
 
-    const updated = loadConfig().profiles.default;
-    expect(updated.sub).toBe("user-1");
-    expect(updated.email).toBe("dev@example.com");
-    expect(updated.identifierType).toBe("email");
+    const portal = loadConfig().portal!;
+    expect(portal.instanceUrl).toBe(PORTAL_URL);
+    expect(portal.sub).toBe("user-1");
+    expect(portal.email).toBe("dev@example.com");
+    expect(portal.identifierType).toBe("email");
 
-    expect(outro).toHaveBeenCalledWith(expect.stringContaining("Logged in as dev@example.com."));
+    // The portal session must not leak into the profile map, which means auth
+    // instances the developer administers.
+    expect(loadConfig().profiles).toEqual({});
+
+    expect(outro).toHaveBeenCalledWith(
+      expect.stringContaining("Signed in to the Seamless portal as dev@example.com."),
+    );
   });
 
   it("falls back to the identifier in the outro message when the response omits email", async () => {
@@ -213,7 +250,9 @@ describe("runLogin: success", () => {
 
     await runLogin([]);
 
-    expect(outro).toHaveBeenCalledWith(expect.stringContaining("Logged in as dev@example.com."));
+    expect(outro).toHaveBeenCalledWith(
+      expect.stringContaining("Signed in to the Seamless portal as dev@example.com."),
+    );
   });
 
   it("cancels when the code prompt is cancelled", async () => {
@@ -367,7 +406,7 @@ describe("runLogin: success", () => {
 
 describe("runLogin: local delivery", () => {
   beforeEach(() => {
-    upsertProfile({ name: "default", instanceUrl: "http://localhost:5312" });
+    process.env.SEAMLESS_PORTAL_AUTH_URL = "http://localhost:5312";
   });
 
   it("auto-fills the OTP from the response without prompting for a code", async () => {
@@ -388,7 +427,10 @@ describe("runLogin: local delivery", () => {
 
     // Only the identifier prompt runs; the code is never prompted.
     expect(vi.mocked(text)).toHaveBeenCalledTimes(1);
-    const stored = await getTokens({ name: "default", instanceUrl: "http://localhost:5312" });
+    const stored = await getTokens({
+      name: "__portal__",
+      instanceUrl: "http://localhost:5312",
+    });
     expect(stored?.accessToken).toBe("a");
 
     const generate = calls.find((c) =>
@@ -399,22 +441,44 @@ describe("runLogin: local delivery", () => {
     ).toBe("external");
   });
 
-  it("rejects --local against a non-local instance", async () => {
-    upsertProfile({ name: "default", instanceUrl: "https://auth.example.com" });
+  it("rejects --local against a non-local portal", async () => {
+    process.env.SEAMLESS_PORTAL_AUTH_URL = PORTAL_URL;
 
     await expect(runLogin(["--local"])).rejects.toThrow("exit:1");
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("--local only works against a local instance"),
+      expect.stringContaining("--local only works against a local portal"),
     );
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 });
 
-describe("runLogin: failure handling", () => {
-  beforeEach(() => {
+describe("runLogin: deprecated --profile shim", () => {
+  it("routes to instance login and warns", async () => {
     upsertProfile(profile);
-  });
+    const calls = mockRouter({
+      "/login": [
+        () => json({ token: "e1", identifierType: "email", loginMethods: ["email_otp"] }),
+      ],
+      "/otp/generate-login-email-otp": [() => json({ message: "sent" })],
+      "/otp/verify-login-email-otp": [
+        () => json({ token: "a", refreshToken: "r", email: "dev@example.com" }),
+      ],
+    });
+    vi.mocked(text).mockResolvedValueOnce("dev@example.com").mockResolvedValueOnce("123456");
 
+    await runLogin(["--profile", "default"]);
+
+    expect(
+      logs().some((l) => l.includes("seamless profile login default")),
+    ).toBe(true);
+    // The instance, not the portal, is the login target.
+    expect(calls.every((c) => c.url.startsWith(profile.instanceUrl))).toBe(true);
+    expect(await getTokens(profile)).not.toBeNull();
+    expect(loadConfig().portal).toBeUndefined();
+  });
+});
+
+describe("runLogin: failure handling", () => {
   it("exits 1 with a red message on a LoginError", async () => {
     vi.stubGlobal(
       "fetch",

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,14 +1,18 @@
-import { intro, outro, text, isCancel, cancel } from "@clack/prompts";
+import { intro, outro, cancel } from "@clack/prompts";
 import kleur from "kleur";
+
 import { extractFlag } from "../core/args.js";
 import {
-  getActiveProfile,
+  getPortalAuthUrl,
+  getPortalSession,
   isLocalInstanceUrl,
-  upsertProfile,
-  type Profile,
+  PORTAL_PROFILE_NAME,
+  savePortalSession,
 } from "../core/config.js";
 import { KeychainUnavailableError, saveTokens } from "../core/keychain.js";
-import { completeLogin, LoginError, type LoginResult } from "../core/loginFlow.js";
+import { promptLogin } from "../core/interactiveLogin.js";
+import { LoginError } from "../core/loginFlow.js";
+import { loginToInstance } from "./instanceLogin.js";
 
 export async function runLogin(args: string[]): Promise<void> {
   const local = args.includes("--local");
@@ -17,97 +21,61 @@ export async function runLogin(args: string[]): Promise<void> {
     "profile",
   );
   const idFlag = extractFlag(profileFlag.rest, "identifier");
+  const identifier = (idFlag.value ?? idFlag.rest[0])?.trim();
 
-  const profile = getActiveProfile({ profileFlag: profileFlag.value });
-  if (!profile) {
-    console.error(kleur.red("No active profile is configured."));
+  // `login --profile <name>` used to be the only way to reach an auth instance.
+  // TODO(#125): drop this shim one minor version after release.
+  if (profileFlag.value) {
     console.log(
-      "Add one with: " +
-        kleur.cyan("seamless profile add <name> --instance-url <url>"),
+      kleur.yellow(
+        `"seamless login --profile ${profileFlag.value}" is deprecated. Use: seamless profile login ${profileFlag.value}`,
+      ),
     );
-    process.exit(1);
+    await loginToInstance({
+      profileName: profileFlag.value,
+      identifier,
+      local,
+    });
+    return;
   }
 
-  if (local && !isLocalInstanceUrl(profile.instanceUrl)) {
+  await loginToPortal({ identifier, local });
+}
+
+// Signs in to the Seamless portal, the managed control plane's own account. The
+// session it stores is what authorizes api.seamlessauth.com, and it is deliberately
+// kept out of the profile map: profiles are auth instances, of which there are
+// many, while there is exactly one portal.
+async function loginToPortal(opts: {
+  identifier?: string;
+  local?: boolean;
+}): Promise<void> {
+  const instanceUrl = getPortalAuthUrl();
+
+  if (opts.local && !isLocalInstanceUrl(instanceUrl)) {
     console.error(
-      kleur.red(`--local only works against a local instance, not ${profile.instanceUrl}.`),
+      kleur.red(
+        `--local only works against a local portal, not ${instanceUrl}. Set SEAMLESS_PORTAL_AUTH_URL to a local instance to develop against one.`,
+      ),
     );
     process.exit(1);
   }
 
-  intro(`Log in to ${kleur.bold(profile.name)} (${profile.instanceUrl})`);
-  if (local) {
+  const existing = getPortalSession();
+
+  intro(`Sign in to the ${kleur.bold("Seamless portal")} (${instanceUrl})`);
+  if (opts.local) {
     console.log(
       kleur.dim("Local delivery on: reading the OTP from the instance response."),
     );
   }
 
-  let identifier = (idFlag.value ?? idFlag.rest[0])?.trim();
-  if (!identifier) {
-    const answer = await text({
-      message: "Email or phone",
-      placeholder: profile.email ?? "you@example.com",
-      initialValue: profile.email ?? "",
-      validate: (value) =>
-        value && value.trim() ? undefined : "An identifier is required",
-    });
-    if (isCancel(answer)) {
-      cancel("Cancelled.");
-      return;
-    }
-    identifier = (answer as string).trim();
-  }
-
   try {
-    const result = await completeLogin({
-      instanceUrl: profile.instanceUrl,
-      identifier,
-      localDelivery: local,
-      getCode: async ({ resent, channel }) => {
-        const email = channel === "email";
-        const answer = await text({
-          message: resent ? "Enter the new code" : "Enter the code we sent you",
-          placeholder: email ? "ABCDEF" : "123456",
-          validate: (value) => {
-            const code = (value ?? "").trim();
-            if (email) {
-              return /^[A-Za-z]{6}$/.test(code)
-                ? undefined
-                : "Enter the 6-letter code from the email.";
-            }
-            return /^\d{4,8}$/.test(code)
-              ? undefined
-              : "Enter the numeric code from the message.";
-          },
-        });
-        if (isCancel(answer)) return null;
-        const code = (answer as string).trim();
-        return email ? code.toUpperCase() : code;
-      },
-      notify: (event) => {
-        switch (event.type) {
-          case "code_sent":
-            console.log(kleur.dim(`A code was sent to ${identifier}.`));
-            break;
-          case "code_resent":
-            console.log(
-              kleur.dim("Your previous code expired, so we sent a new one."),
-            );
-            break;
-          case "code_autofilled":
-            console.log(kleur.dim("Read the code from the instance response."));
-            break;
-          case "incorrect":
-            console.log(
-              kleur.yellow(
-                `That code was not accepted. ${event.attemptsLeft} attempt${
-                  event.attemptsLeft === 1 ? "" : "s"
-                } left.`,
-              ),
-            );
-            break;
-        }
-      },
+    const result = await promptLogin({
+      instanceUrl,
+      identifier: opts.identifier,
+      knownEmail: existing?.email,
+      localDelivery: opts.local,
     });
 
     if (!result) {
@@ -115,8 +83,22 @@ export async function runLogin(args: string[]): Promise<void> {
       return;
     }
 
-    await persistSession(profile, result);
-    outro(kleur.green(`Logged in as ${result.identity.email ?? identifier}.`));
+    await saveTokens(
+      { name: PORTAL_PROFILE_NAME, instanceUrl },
+      result.tokens,
+    );
+    savePortalSession({
+      instanceUrl,
+      sub: result.identity.sub,
+      email: result.identity.email,
+      identifierType: result.identity.identifierType,
+    });
+
+    outro(
+      kleur.green(
+        `Signed in to the Seamless portal as ${result.identity.email ?? result.identifier}.`,
+      ),
+    );
   } catch (err) {
     if (err instanceof LoginError || err instanceof KeychainUnavailableError) {
       outro(kleur.red(err.message));
@@ -124,17 +106,4 @@ export async function runLogin(args: string[]): Promise<void> {
     }
     throw err;
   }
-}
-
-async function persistSession(
-  profile: Profile,
-  result: LoginResult,
-): Promise<void> {
-  await saveTokens(profile, result.tokens);
-  upsertProfile({
-    ...profile,
-    sub: result.identity.sub ?? profile.sub,
-    email: result.identity.email ?? profile.email,
-    identifierType: result.identity.identifierType,
-  });
 }

--- a/src/commands/logout.test.ts
+++ b/src/commands/logout.test.ts
@@ -2,7 +2,12 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { upsertProfile } from "../core/config.js";
+import {
+  loadConfig,
+  PORTAL_PROFILE_NAME,
+  savePortalSession,
+  upsertProfile,
+} from "../core/config.js";
 import { getTokens, saveTokens, setBackendForTesting, type KeychainBackend } from "../core/keychain.js";
 import { runLogout } from "./logout.js";
 
@@ -45,6 +50,70 @@ afterEach(() => {
   setBackendForTesting(null);
   fs.rmSync(configHome, { recursive: true, force: true });
   delete process.env.XDG_CONFIG_HOME;
+  delete process.env.SEAMLESS_PORTAL_AUTH_URL;
+});
+
+describe("runLogout: portal", () => {
+  const portalUrl = "https://portal.example.com";
+  const portalTarget = { name: PORTAL_PROFILE_NAME, instanceUrl: portalUrl };
+
+  beforeEach(() => {
+    process.env.SEAMLESS_PORTAL_AUTH_URL = portalUrl;
+  });
+
+  it("revokes and clears the portal session by default", async () => {
+    savePortalSession({ instanceUrl: portalUrl, email: "dev@example.com" });
+    await saveTokens(portalTarget, { accessToken: "a", refreshToken: "r" });
+    upsertProfile(profile);
+    await saveTokens(profile, { accessToken: "ia", refreshToken: "ir" });
+
+    const calls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        calls.push(url);
+        return json({ ok: true });
+      }),
+    );
+
+    await runLogout([]);
+
+    expect(calls[0]).toBe(`${portalUrl}/logout`);
+    expect(await getTokens(portalTarget)).toBeNull();
+    expect(loadConfig().portal).toBeUndefined();
+    // The instance session is a separate account and must survive.
+    expect(await getTokens(profile)).not.toBeNull();
+    expect(logs().some((l) => l.includes("Logged out."))).toBe(true);
+  });
+
+  it("clears a stale portal session without a live token", async () => {
+    savePortalSession({ instanceUrl: portalUrl });
+
+    await runLogout([]);
+
+    expect(loadConfig().portal).toBeUndefined();
+    expect(logs().some((l) => l.includes("You are already logged out."))).toBe(
+      true,
+    );
+  });
+
+  it("targets an instance when --profile is given", async () => {
+    savePortalSession({ instanceUrl: portalUrl });
+    await saveTokens(portalTarget, { accessToken: "a", refreshToken: "r" });
+    upsertProfile(profile);
+    await saveTokens(profile, { accessToken: "ia", refreshToken: "ir" });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => json({ ok: true })),
+    );
+
+    await runLogout(["--profile", "default"]);
+
+    expect(await getTokens(profile)).toBeNull();
+    expect(loadConfig().portal).toBeDefined();
+    expect(await getTokens(portalTarget)).not.toBeNull();
+  });
 });
 
 function logs(): string[] {
@@ -54,7 +123,7 @@ function logs(): string[] {
 describe("runLogout", () => {
   it("does nothing when there is no active profile", async () => {
     await runLogout([]);
-    expect(logs().some((l) => l.includes("No active profile. Nothing to log out of."))).toBe(
+    expect(logs().some((l) => l.includes("No session to log out of."))).toBe(
       true,
     );
   });

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,7 +1,16 @@
 import kleur from "kleur";
 import { extractFlag } from "../core/args.js";
-import { createAuthClient, ReauthRequiredError } from "../core/authClient.js";
-import { getActiveProfile } from "../core/config.js";
+import {
+  createAuthClient,
+  createPortalClient,
+  ReauthRequiredError,
+} from "../core/authClient.js";
+import {
+  clearPortalSession,
+  getActiveProfile,
+  getPortalSession,
+  type Profile,
+} from "../core/config.js";
 import { clearLocalSession, revokeSession } from "../core/session.js";
 
 export async function runLogout(args: string[]): Promise<void> {
@@ -11,18 +20,24 @@ export async function runLogout(args: string[]): Promise<void> {
     "profile",
   );
 
-  const profile = getActiveProfile({ profileFlag });
-  if (!profile) {
-    console.log(kleur.yellow("No active profile. Nothing to log out of."));
+  // Mirrors whoami: the portal is the default target, an instance profile is the
+  // fallback for developers who never sign in to the control plane.
+  const portal = !profileFlag ? getPortalSession() : undefined;
+  const target = portal ?? getActiveProfile({ profileFlag });
+
+  if (!target) {
+    console.log(kleur.yellow("No session to log out of."));
     return;
   }
 
   let client;
   try {
-    client = await createAuthClient({ profileFlag });
+    client = portal
+      ? await createPortalClient()
+      : await createAuthClient({ profileFlag });
   } catch (err) {
     if (err instanceof ReauthRequiredError) {
-      await clearLocalSession(profile);
+      await forget(target, portal !== undefined);
       console.log(kleur.green("You are already logged out."));
       return;
     }
@@ -37,7 +52,7 @@ export async function runLogout(args: string[]): Promise<void> {
     revoked = true;
   }
 
-  await clearLocalSession(profile);
+  await forget(target, portal !== undefined);
 
   if (revoked) {
     console.log(
@@ -50,4 +65,9 @@ export async function runLogout(args: string[]): Promise<void> {
       ),
     );
   }
+}
+
+async function forget(target: Profile, portal: boolean): Promise<void> {
+  await clearLocalSession(target);
+  if (portal) clearPortalSession();
 }

--- a/src/commands/profile.test.ts
+++ b/src/commands/profile.test.ts
@@ -295,3 +295,69 @@ describe("runProfile remove", () => {
     expect(logs().some((l) => l.includes('Profile "prod" removed.'))).toBe(true);
   });
 });
+
+describe("profile add: reserved names", () => {
+  it("rejects the name used for the portal session", async () => {
+    await expect(
+      runProfile([
+        "add",
+        "__portal__",
+        "--instance-url",
+        "https://auth.example.com",
+      ]),
+    ).rejects.toThrow("exit:1");
+
+    expect(outro).toHaveBeenCalledWith(
+      expect.stringContaining("reserved for the portal session"),
+    );
+    expect(loadConfig().profiles.__portal__).toBeUndefined();
+  });
+});
+
+describe("profile login", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        const body = url.endsWith("/login")
+          ? { token: "e1", identifierType: "email", loginMethods: ["email_otp"] }
+          : url.endsWith("/otp/generate-login-email-otp")
+            ? { message: "sent" }
+            : { token: "a", refreshToken: "r", email: "dev@example.com" };
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("signs in to the named profile without changing the active one", async () => {
+    upsertProfile({ name: "default", instanceUrl: "https://auth.example.com" });
+    const prod = { name: "prod", instanceUrl: "https://prod.example.com" };
+    upsertProfile(prod);
+    vi.mocked(text).mockResolvedValueOnce("123456");
+
+    await runProfile(["login", "prod", "dev@example.com"]);
+
+    expect(await getTokens(prod)).not.toBeNull();
+    expect(loadConfig().activeProfile).toBe("default");
+    expect(loadConfig().portal).toBeUndefined();
+  });
+
+  it("accepts --identifier and falls back to the active profile", async () => {
+    const active = { name: "default", instanceUrl: "https://auth.example.com" };
+    upsertProfile(active);
+    vi.mocked(text).mockResolvedValueOnce("123456");
+
+    await runProfile(["login", "--identifier", "dev@example.com"]);
+
+    expect(await getTokens(active)).not.toBeNull();
+    // Only the code prompt ran; the identifier came from the flag.
+    expect(vi.mocked(text)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -2,6 +2,7 @@ import { intro, outro, text, isCancel, cancel } from "@clack/prompts";
 import kleur from "kleur";
 import { extractFlag } from "../core/args.js";
 import {
+  assertUsableProfileName,
   DEFAULT_PROFILE_NAME,
   loadConfig,
   normalizeInstanceUrl,
@@ -12,6 +13,7 @@ import {
   type IdentifierType,
 } from "../core/config.js";
 import { deleteTokens, KeychainUnavailableError } from "../core/keychain.js";
+import { loginToInstance } from "./instanceLogin.js";
 
 export async function runProfile(args: string[]): Promise<void> {
   const sub = args[0];
@@ -30,11 +32,14 @@ export async function runProfile(args: string[]): Promise<void> {
     case "remove":
       await profileRemove(rest);
       return;
+    case "login":
+      await profileLogin(rest);
+      return;
     default:
       console.error(
         kleur.red(`Unknown profile subcommand: ${sub ?? "(none)"}`),
       );
-      console.log("Usage: seamless profile <list|add|use|remove>");
+      console.log("Usage: seamless profile <list|add|use|remove|login>");
       process.exit(1);
   }
 }
@@ -89,6 +94,13 @@ async function profileAdd(rest: string[]): Promise<void> {
     name = (answer as string) || DEFAULT_PROFILE_NAME;
   }
 
+  try {
+    assertUsableProfileName(name);
+  } catch (err) {
+    outro(kleur.red((err as Error).message));
+    process.exit(1);
+  }
+
   if (!instanceUrl) {
     const answer = await text({
       message: "Instance URL",
@@ -127,6 +139,21 @@ async function profileAdd(rest: string[]): Promise<void> {
   });
 
   outro(kleur.green(`Profile "${name}" saved (${normalized})`));
+}
+
+// Signs in to a profile's instance without switching the active profile, so a
+// one-off admin command against another instance does not disturb the default.
+async function profileLogin(rest: string[]): Promise<void> {
+  const local = rest.includes("--local");
+  const withoutLocal = rest.filter((a) => a !== "--local");
+  const idFlag = extractFlag(withoutLocal, "identifier");
+  const positional = idFlag.rest.filter((a) => !a.startsWith("-"));
+
+  await loginToInstance({
+    profileName: positional[0],
+    identifier: idFlag.value ?? positional[1],
+    local,
+  });
 }
 
 function profileUse(rest: string[]): void {

--- a/src/commands/whoami.test.ts
+++ b/src/commands/whoami.test.ts
@@ -2,7 +2,11 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { upsertProfile } from "../core/config.js";
+import {
+  PORTAL_PROFILE_NAME,
+  savePortalSession,
+  upsertProfile,
+} from "../core/config.js";
 import { saveTokens, setBackendForTesting, type KeychainBackend } from "../core/keychain.js";
 import { runWhoami } from "./whoami.js";
 
@@ -54,6 +58,51 @@ afterEach(() => {
   setBackendForTesting(null);
   fs.rmSync(configHome, { recursive: true, force: true });
   delete process.env.XDG_CONFIG_HOME;
+  delete process.env.SEAMLESS_PORTAL_AUTH_URL;
+});
+
+describe("runWhoami: portal", () => {
+  const portalUrl = "https://portal.example.com";
+
+  beforeEach(async () => {
+    process.env.SEAMLESS_PORTAL_AUTH_URL = portalUrl;
+    savePortalSession({ instanceUrl: portalUrl, email: "dev@example.com" });
+    await saveTokens(
+      { name: PORTAL_PROFILE_NAME, instanceUrl: portalUrl },
+      { accessToken: "portal-access", refreshToken: "portal-refresh" },
+    );
+  });
+
+  it("reports the portal account by default, even with an active profile", async () => {
+    const calls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        calls.push(url);
+        return json({ user: { id: "portal-user", email: "dev@example.com", roles: [] } });
+      }),
+    );
+
+    await runWhoami([]);
+
+    const lines = logSpy.mock.calls.map((c) => c[0] as string);
+    expect(lines.some((l) => l.includes("Account") && l.includes("Seamless portal"))).toBe(true);
+    expect(lines.some((l) => l.includes("portal-user"))).toBe(true);
+    expect(calls[0]).toBe(`${portalUrl}/users/me`);
+  });
+
+  it("still targets an instance when --profile is given", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => json({ user: { id: "instance-user", roles: [] } })),
+    );
+
+    await runWhoami(["--profile", "default"]);
+
+    const lines = logSpy.mock.calls.map((c) => c[0] as string);
+    expect(lines.some((l) => l.includes("Account") && l.includes("default"))).toBe(true);
+    expect(lines.some((l) => l.includes("instance-user"))).toBe(true);
+  });
 });
 
 describe("runWhoami", () => {
@@ -70,7 +119,7 @@ describe("runWhoami", () => {
     await runWhoami([]);
 
     const lines = logSpy.mock.calls.map((c) => c[0] as string);
-    expect(lines.some((l) => l.includes("Profile") && l.includes("default"))).toBe(true);
+    expect(lines.some((l) => l.includes("Account") && l.includes("default"))).toBe(true);
     expect(lines.some((l) => l.includes("Instance") && l.includes(profile.instanceUrl))).toBe(
       true,
     );
@@ -117,7 +166,7 @@ describe("runWhoami", () => {
     });
 
     await expect(runWhoami([])).rejects.toThrow("exit:1");
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Run: seamless login."));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Run: seamless profile login default."));
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
@@ -147,7 +196,7 @@ describe("runWhoami", () => {
     await runWhoami(["--profile", "other"]);
 
     const lines = logSpy.mock.calls.map((c) => c[0] as string);
-    expect(lines.some((l) => l.includes("Profile") && l.includes("other"))).toBe(true);
+    expect(lines.some((l) => l.includes("Account") && l.includes("other"))).toBe(true);
     expect(lines.some((l) => l.includes("other-user"))).toBe(true);
   });
 });

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -1,16 +1,29 @@
 import kleur from "kleur";
 import { extractFlag } from "../core/args.js";
-import { createAuthClient, ReauthRequiredError } from "../core/authClient.js";
+import {
+  createAuthClient,
+  createPortalClient,
+  ReauthRequiredError,
+} from "../core/authClient.js";
 import { fetchIdentity, type Identity } from "../core/session.js";
-import type { Profile } from "../core/config.js";
+import { getPortalSession, type Profile } from "../core/config.js";
 
 export async function runWhoami(args: string[]): Promise<void> {
   const { value: profileFlag } = extractFlag(args, "profile");
 
   try {
-    const client = await createAuthClient({ profileFlag });
+    // Without --profile this reports the portal account. An instance profile is
+    // still a useful answer when there is no portal session (a local-only or
+    // self-hosted developer never signs in to the control plane), so fall back
+    // to it rather than reporting nothing.
+    const portal = !profileFlag && getPortalSession() !== undefined;
+    const client =
+      profileFlag || !portal
+        ? await createAuthClient({ profileFlag })
+        : await createPortalClient();
+
     const identity = await fetchIdentity(client);
-    printIdentity(client.profile, identity);
+    printIdentity(portal ? "Seamless portal" : client.profile.name, client.profile, identity);
   } catch (err) {
     if (err instanceof ReauthRequiredError) {
       console.log(kleur.yellow(err.message));
@@ -21,11 +34,15 @@ export async function runWhoami(args: string[]): Promise<void> {
   }
 }
 
-function printIdentity(profile: Profile, identity: Identity): void {
+function printIdentity(
+  target: string,
+  profile: Profile,
+  identity: Identity,
+): void {
   const line = (label: string, value: string) =>
     console.log(kleur.dim(`${label}:`.padEnd(11)) + value);
 
-  line("Profile", profile.name);
+  line("Account", target);
   line("Instance", profile.instanceUrl);
   line("Sub", identity.sub ?? profile.sub ?? "(unknown)");
   line("Email", identity.email ?? profile.email ?? "(unknown)");

--- a/src/core/authClient.test.ts
+++ b/src/core/authClient.test.ts
@@ -2,7 +2,11 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { upsertProfile } from "./config.js";
+import {
+  PORTAL_PROFILE_NAME,
+  savePortalSession,
+  upsertProfile,
+} from "./config.js";
 import { isRateLimited } from "./http.js";
 import {
   getTokens,
@@ -13,6 +17,7 @@ import {
 } from "./keychain.js";
 import {
   createAuthClient,
+  createPortalClient,
   ReauthRequiredError,
   tokensFromAuthResponse,
 } from "./authClient.js";
@@ -88,6 +93,77 @@ describe("createAuthClient", () => {
 
   it("throws a reauth error when there is no session", async () => {
     await expect(createAuthClient()).rejects.toBeInstanceOf(ReauthRequiredError);
+  });
+
+  it("points at the instance login command when a profile has no session", async () => {
+    await expect(createAuthClient()).rejects.toThrow(
+      "Run: seamless profile login default.",
+    );
+  });
+});
+
+describe("createPortalClient", () => {
+  const portalUrl = "https://portal.example.com";
+  const portalTarget = { name: PORTAL_PROFILE_NAME, instanceUrl: portalUrl };
+
+  beforeEach(() => {
+    process.env.SEAMLESS_PORTAL_AUTH_URL = portalUrl;
+  });
+
+  afterEach(() => {
+    delete process.env.SEAMLESS_PORTAL_AUTH_URL;
+  });
+
+  it("throws a reauth error naming seamless login when signed out", async () => {
+    await expect(createPortalClient()).rejects.toBeInstanceOf(
+      ReauthRequiredError,
+    );
+    await expect(createPortalClient()).rejects.toThrow("Run: seamless login.");
+  });
+
+  // An instance profile with a session must not stand in for a portal account:
+  // its token is issued by a different host and the control plane would reject it.
+  it("ignores an instance profile session", async () => {
+    await saveTokens(profile, { accessToken: "a", refreshToken: "r" });
+
+    await expect(createPortalClient()).rejects.toBeInstanceOf(
+      ReauthRequiredError,
+    );
+  });
+
+  it("sends the portal session to an absolute control-plane URL", async () => {
+    savePortalSession({ instanceUrl: portalUrl });
+    await saveTokens(portalTarget, {
+      accessToken: "portal-access",
+      refreshToken: "portal-refresh",
+    });
+    const calls = mockFetch([() => json({ applications: [] })]);
+
+    const client = await createPortalClient();
+    await client.get("https://api.seamlessauth.com/applications");
+
+    expect(calls[0].url).toBe("https://api.seamlessauth.com/applications");
+    expect(authHeader(calls[0])).toBe("Bearer portal-access");
+  });
+
+  it("refreshes against the portal auth host, not the control plane", async () => {
+    savePortalSession({ instanceUrl: portalUrl });
+    await saveTokens(portalTarget, {
+      accessToken: "stale",
+      refreshToken: "portal-refresh",
+    });
+    const calls = mockFetch([
+      () => json({ error: "expired" }, 401),
+      () => json({ token: "fresh", refreshToken: "rotated" }),
+      () => json({ applications: [] }),
+    ]);
+
+    const client = await createPortalClient();
+    await client.get("https://api.seamlessauth.com/applications");
+
+    expect(calls[1].url).toBe(`${portalUrl}/refresh`);
+    expect(authHeader(calls[2])).toBe("Bearer fresh");
+    expect((await getTokens(portalTarget))?.refreshToken).toBe("rotated");
   });
 });
 

--- a/src/core/authClient.ts
+++ b/src/core/authClient.ts
@@ -1,4 +1,8 @@
-import { getActiveProfile, type Profile } from "./config.js";
+import {
+  getActiveProfile,
+  getPortalSession,
+  type Profile,
+} from "./config.js";
 import {
   deleteTokens,
   getTokens,
@@ -50,20 +54,56 @@ export function tokensFromAuthResponse(
   };
 }
 
+// A client for an auth instance a developer administers, resolved from the active
+// profile. Portal calls use createPortalClient instead: the two sessions are
+// different accounts on different hosts and must never be interchanged.
 export async function createAuthClient(
   opts: { profileFlag?: string } = {},
 ): Promise<AuthClient> {
   const profile = getActiveProfile(opts);
   if (!profile) {
     throw new ReauthRequiredError(
-      "No active profile is configured. Add one with: seamless profile add <name> --instance-url <url>, then run seamless login.",
+      "No active profile is configured. Add one with: seamless profile add <name> --instance-url <url>, then run seamless profile login <name>.",
     );
   }
 
-  let tokens = await getTokens(profile);
+  return createClientForProfile(profile, {
+    label: `profile "${profile.name}"`,
+    reauthCommand: `seamless profile login ${profile.name}`,
+  });
+}
+
+// A client for the Seamless portal, used for control-plane calls
+// (core/portal.ts). Absolute URLs pass through joinUrl untouched, so the same
+// client reaches api.seamlessauth.com while refreshing against the portal's own
+// auth host.
+export async function createPortalClient(): Promise<AuthClient> {
+  const session = getPortalSession();
+  if (!session) {
+    throw new ReauthRequiredError(
+      "You are not signed in to the Seamless portal. Run: seamless login.",
+    );
+  }
+
+  return createClientForProfile(session, {
+    label: "the Seamless portal",
+    reauthCommand: "seamless login",
+  });
+}
+
+interface ReauthCopy {
+  label: string;
+  reauthCommand: string;
+}
+
+async function createClientForProfile(
+  profile: Profile,
+  copy: ReauthCopy,
+): Promise<AuthClient> {
+  const tokens = await getTokens(profile);
   if (!tokens || !tokens.refreshToken) {
     throw new ReauthRequiredError(
-      `No session for profile "${profile.name}". Run: seamless login.`,
+      `No session for ${copy.label}. Run: ${copy.reauthCommand}.`,
     );
   }
   const session = tokens;
@@ -100,7 +140,7 @@ export async function createAuthClient(
     if (!res.ok) {
       await clearSession();
       throw new ReauthRequiredError(
-        `Your session for "${profile.name}" has expired or was revoked. Run: seamless login.`,
+        `Your session for ${copy.label} has expired or was revoked. Run: ${copy.reauthCommand}.`,
       );
     }
 
@@ -108,7 +148,7 @@ export async function createAuthClient(
     if (!next) {
       await clearSession();
       throw new ReauthRequiredError(
-        `Received an unexpected refresh response from ${profile.instanceUrl}. Run: seamless login.`,
+        `Received an unexpected refresh response from ${profile.instanceUrl}. Run: ${copy.reauthCommand}.`,
       );
     }
 

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -3,13 +3,20 @@ import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  assertUsableProfileName,
+  clearPortalSession,
+  DEFAULT_PORTAL_AUTH_URL,
   getConfigPath,
+  getPortalAuthUrl,
+  getPortalSession,
   getProfile,
   listProfiles,
   loadConfig,
   normalizeInstanceUrl,
+  PORTAL_PROFILE_NAME,
   removeProfile,
   resolveActiveProfileName,
+  savePortalSession,
   setActiveProfile,
   upsertProfile,
 } from "./config.js";
@@ -26,6 +33,89 @@ afterEach(() => {
   fs.rmSync(configHome, { recursive: true, force: true });
   delete process.env.XDG_CONFIG_HOME;
   delete process.env.SEAMLESS_PROFILE;
+  delete process.env.SEAMLESS_PORTAL_AUTH_URL;
+});
+
+describe("getPortalAuthUrl", () => {
+  it("defaults to the managed portal auth instance", () => {
+    expect(getPortalAuthUrl()).toBe(DEFAULT_PORTAL_AUTH_URL);
+  });
+
+  it("honors SEAMLESS_PORTAL_AUTH_URL and normalizes it", () => {
+    process.env.SEAMLESS_PORTAL_AUTH_URL = "http://localhost:5312/";
+    expect(getPortalAuthUrl()).toBe("http://localhost:5312");
+  });
+
+  it("rejects an override that is not a valid instance URL", () => {
+    process.env.SEAMLESS_PORTAL_AUTH_URL = "not-a-url";
+    expect(() => getPortalAuthUrl()).toThrow(/Invalid instance URL/);
+  });
+});
+
+describe("assertUsableProfileName", () => {
+  it("rejects the reserved portal name", () => {
+    expect(() => assertUsableProfileName(PORTAL_PROFILE_NAME)).toThrow(
+      /reserved for the portal session/,
+    );
+  });
+
+  it("accepts an ordinary name", () => {
+    expect(() => assertUsableProfileName("prod")).not.toThrow();
+  });
+});
+
+describe("portal session", () => {
+  beforeEach(() => {
+    process.env.SEAMLESS_PORTAL_AUTH_URL = "https://portal.example.com";
+  });
+
+  it("is undefined before signing in", () => {
+    expect(getPortalSession()).toBeUndefined();
+  });
+
+  it("round-trips and stays out of the profile map", () => {
+    savePortalSession({
+      instanceUrl: "https://portal.example.com",
+      sub: "user-1",
+      email: "dev@example.com",
+      identifierType: "email",
+    });
+
+    const session = getPortalSession()!;
+    expect(session.name).toBe(PORTAL_PROFILE_NAME);
+    expect(session.email).toBe("dev@example.com");
+    expect(loadConfig().profiles).toEqual({});
+    expect(listProfiles()).toEqual([]);
+  });
+
+  // Tokens are keyed by host, so a session for another portal is unusable here
+  // and must read as signed out rather than being silently reused.
+  it("is undefined when it belongs to a different portal host", () => {
+    savePortalSession({ instanceUrl: "https://portal.example.com" });
+    process.env.SEAMLESS_PORTAL_AUTH_URL = "https://other.example.com";
+
+    expect(getPortalSession()).toBeUndefined();
+    expect(loadConfig().portal).toBeDefined();
+  });
+
+  it("clears", () => {
+    savePortalSession({ instanceUrl: "https://portal.example.com" });
+    clearPortalSession();
+
+    expect(getPortalSession()).toBeUndefined();
+    expect(loadConfig().portal).toBeUndefined();
+  });
+
+  it("survives a reload and ignores a malformed stored value", () => {
+    savePortalSession({ instanceUrl: "https://portal.example.com" });
+    expect(loadConfig().portal?.instanceUrl).toBe("https://portal.example.com");
+
+    fs.writeFileSync(
+      getConfigPath(),
+      JSON.stringify({ activeProfile: "default", profiles: {}, portal: 42 }),
+    );
+    expect(loadConfig().portal).toBeUndefined();
+  });
 });
 
 describe("loadConfig", () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -15,9 +15,27 @@ export interface Profile {
 export interface SeamlessConfig {
   activeProfile: string;
   profiles: Record<string, Profile>;
+  // The Seamless portal session. There is exactly one, so it lives beside the
+  // profile map rather than inside it: profiles are auth instances a developer
+  // administers, the portal is the managed control plane's own account.
+  portal?: Profile;
 }
 
 export const DEFAULT_PROFILE_NAME = "default";
+
+// Reserved profile name for the portal session's keychain entry, so it can never
+// collide with a developer's own profile (see assertUsableProfileName).
+export const PORTAL_PROFILE_NAME = "__portal__";
+
+// The portal's first-party auth instance (portal-auth in seamless-iac), which
+// issues the sessions api.seamlessauth.com accepts. Paired with getPortalApiUrl
+// in core/portal.ts, which lives there to avoid an import cycle.
+export const DEFAULT_PORTAL_AUTH_URL = "https://seamless.seamlessauth.com";
+
+export function getPortalAuthUrl(): string {
+  const override = process.env.SEAMLESS_PORTAL_AUTH_URL?.trim();
+  return normalizeInstanceUrl(override || DEFAULT_PORTAL_AUTH_URL);
+}
 
 export function getConfigDir(): string {
   const xdg = process.env.XDG_CONFIG_HOME?.trim();
@@ -66,7 +84,12 @@ function normalizeLoaded(parsed: unknown): SeamlessConfig {
       ? raw.activeProfile
       : DEFAULT_PROFILE_NAME;
 
-  return { activeProfile: active, profiles };
+  const config: SeamlessConfig = { activeProfile: active, profiles };
+
+  const portal = coerceProfile(PORTAL_PROFILE_NAME, raw.portal);
+  if (portal) config.portal = portal;
+
+  return config;
 }
 
 export function loadConfig(): SeamlessConfig {
@@ -167,6 +190,42 @@ export function getActiveProfile(
 ): Profile | undefined {
   const config = loadConfig();
   return config.profiles[resolveActiveProfileName(opts, config)];
+}
+
+// Rejects the reserved portal name so a developer's profile can never share a
+// keychain account with the portal session.
+export function assertUsableProfileName(name: string): void {
+  if (name === PORTAL_PROFILE_NAME) {
+    throw new Error(
+      `"${PORTAL_PROFILE_NAME}" is reserved for the portal session. Pick another profile name.`,
+    );
+  }
+}
+
+// The stored portal session, but only when it belongs to the portal the CLI is
+// currently pointed at. Switching SEAMLESS_PORTAL_AUTH_URL therefore reads as
+// logged out rather than silently reusing a session from the other host, whose
+// tokens are keyed to that host anyway.
+export function getPortalSession(
+  config: SeamlessConfig = loadConfig(),
+): Profile | undefined {
+  const portal = config.portal;
+  if (!portal) return undefined;
+  return portal.instanceUrl === getPortalAuthUrl() ? portal : undefined;
+}
+
+export function savePortalSession(session: Omit<Profile, "name">): SeamlessConfig {
+  const config = loadConfig();
+  config.portal = { ...session, name: PORTAL_PROFILE_NAME };
+  saveConfig(config);
+  return config;
+}
+
+export function clearPortalSession(): SeamlessConfig {
+  const config = loadConfig();
+  delete config.portal;
+  saveConfig(config);
+  return config;
 }
 
 const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);

--- a/src/core/interactiveLogin.ts
+++ b/src/core/interactiveLogin.ts
@@ -1,0 +1,94 @@
+import { text, isCancel } from "@clack/prompts";
+import kleur from "kleur";
+
+import { completeLogin, type LoginResult } from "./loginFlow.js";
+
+export interface InteractiveLoginOptions {
+  instanceUrl: string;
+  /** Skips the identifier prompt when already known (a flag, or a saved email). */
+  identifier?: string;
+  /** Prefills the identifier prompt, typically the last email used here. */
+  knownEmail?: string;
+  localDelivery?: boolean;
+}
+
+// The resolved identifier travels back with the result so callers can name the
+// account in their summary line when the instance response omits an email.
+export type InteractiveLoginResult = LoginResult & { identifier: string };
+
+// The shared OTP conversation behind `seamless login` (the portal) and
+// `seamless profile login` (an auth instance). Both talk to a Seamless Auth
+// instance over the same endpoints, so only the target URL differs.
+// Returns null when the developer cancels a prompt.
+export async function promptLogin(
+  opts: InteractiveLoginOptions,
+): Promise<InteractiveLoginResult | null> {
+  let identifier = opts.identifier?.trim();
+
+  if (!identifier) {
+    const answer = await text({
+      message: "Email or phone",
+      placeholder: opts.knownEmail ?? "you@example.com",
+      initialValue: opts.knownEmail ?? "",
+      validate: (value) =>
+        value && value.trim() ? undefined : "An identifier is required",
+    });
+    if (isCancel(answer)) return null;
+    identifier = (answer as string).trim();
+  }
+
+  const resolved = identifier;
+
+  const result = await completeLogin({
+    instanceUrl: opts.instanceUrl,
+    identifier: resolved,
+    localDelivery: opts.localDelivery ?? false,
+    getCode: async ({ resent, channel }) => {
+      const email = channel === "email";
+      const answer = await text({
+        message: resent ? "Enter the new code" : "Enter the code we sent you",
+        placeholder: email ? "ABCDEF" : "123456",
+        validate: (value) => {
+          const code = (value ?? "").trim();
+          if (email) {
+            return /^[A-Za-z]{6}$/.test(code)
+              ? undefined
+              : "Enter the 6-letter code from the email.";
+          }
+          return /^\d{4,8}$/.test(code)
+            ? undefined
+            : "Enter the numeric code from the message.";
+        },
+      });
+      if (isCancel(answer)) return null;
+      const code = (answer as string).trim();
+      return email ? code.toUpperCase() : code;
+    },
+    notify: (event) => {
+      switch (event.type) {
+        case "code_sent":
+          console.log(kleur.dim(`A code was sent to ${resolved}.`));
+          break;
+        case "code_resent":
+          console.log(
+            kleur.dim("Your previous code expired, so we sent a new one."),
+          );
+          break;
+        case "code_autofilled":
+          console.log(kleur.dim("Read the code from the instance response."));
+          break;
+        case "incorrect":
+          console.log(
+            kleur.yellow(
+              `That code was not accepted. ${event.attemptsLeft} attempt${
+                event.attemptsLeft === 1 ? "" : "s"
+              } left.`,
+            ),
+          );
+          break;
+      }
+    },
+  });
+
+  return result ? { ...result, identifier: resolved } : null;
+}


### PR DESCRIPTION
Closes #125.

`seamless login` now signs in to the Seamless portal instead of the active profile's instance, and
runs with no configuration at all.

## Why

The CLI signs in to two different things, and until now both went through `getActiveProfile()`:

- **Portal identity**, one per developer, on a fixed host, which authorizes `/applications` and
  `rotateServiceToken` on `api.seamlessauth.com`.
- **Instance identity**, one per auth instance, in that instance's own user pool, which authorizes
  `/admin/*` behind `users`, `config`, `org`, and `sessions`.

Conflating them meant a managed customer had to know and type an instance URL before `login` would
run, and a local-only developer who ran `profile add local --instance-url http://localhost:5312`
followed by `login` made `resolveManagedClient` succeed. `init` then took the managed path and sent
a localhost-issued token to the control plane, failing with "Run: seamless login" for someone who
had just run it.

## What changed

- `login` authenticates against `https://seamless.seamlessauth.com` (the `portal-auth` runtime in
  seamless-iac), overridable with `SEAMLESS_PORTAL_AUTH_URL`. No profile required.
- The portal session is stored under a new top-level `portal` key in `config.json`, not inside
  `profiles`, with its own reserved keychain account. Existing configs stay valid untouched, so
  there is no migration: every profile already on disk is an instance profile. `profile add` now
  rejects the reserved name.
- `createPortalClient` is the only client `listApplications` and `rotateServiceToken` see. An
  instance session can no longer stand in for a portal account.
- A stored portal session is ignored when it belongs to a different host than the one currently
  configured, so switching `SEAMLESS_PORTAL_AUTH_URL` reads as signed out rather than silently
  reusing tokens that host would reject.
- Instance login moves to `seamless profile login [name]`, which does not change the active profile.
- `whoami` and `logout` default to the portal and take `--profile <name>` for an instance. Both fall
  back to the active profile when there is no portal session, so a local-only or self-hosted
  developer is unaffected.
- The OTP conversation is shared by both paths in `src/core/interactiveLogin.ts`.

## Deprecations

- `seamless login --profile <name>` still performs an instance login and prints a pointer to
  `seamless profile login`.
- `seamless init --profile <name>` warns that it is ignored, since managed connect reads the portal
  session now.

Both are marked `TODO(#125)` for removal one minor version after release.

## Testing

`npm run build` and `npm test` pass (640 passed, 4 skipped). `npm run coverage` holds the
thresholds: 99.32% lines, 96.1% branches, 99.65% functions. New tests cover the portal session
helpers, `createPortalClient` (including that it ignores an instance session and refreshes against
the portal host rather than the control plane), `profile login`, the deprecation shim, and the
portal defaults in `whoami` and `logout`.

Not yet exercised against the live portal, which is the point of merging this one on its own.

## Out of scope

Tracked separately: `init` prompting to connect a managed instance and auto-creating the profile
from `app.domain`, lazy re-auth so an admin command prompts inline instead of exiting, and the
`OWNER_EMAIL` work for the local flow.
