### PR TITLE
docs: correct the portal client comment in portal.ts

### DIFF
--- a/src/core/portal.ts
+++ b/src/core/portal.ts
@@ -1,10 +1,11 @@
 import type { AuthClient } from "./authClient.js";
 import { joinUrl } from "./http.js";
 
-// The managed control plane (seamless-portal-api). It is fronted by the same
-// Seamless Auth server a developer logs into, so the CLI reuses the active
-// profile's keychain session (Bearer) to call it. Override the host for staging
-// or local portal development with SEAMLESS_PORTAL_API_URL.
+// The managed control plane (seamless-portal-api). It only recognizes sessions
+// from the portal's own auth instance (getPortalAuthUrl), so these calls take a
+// createPortalClient and never the active profile's client: an instance session
+// belongs to a different user pool on a different host. Override the host for
+// staging or local portal development with SEAMLESS_PORTAL_API_URL.
 export const DEFAULT_PORTAL_API_URL = "https://api.seamlessauth.com";
 
 export function getPortalApiUrl(): string {


### PR DESCRIPTION
## Why

`src/core/portal.ts` opens with a comment describing the pre-#125 world:

> It is fronted by the same Seamless Auth server a developer logs into, so the CLI reuses the active profile's keychain session (Bearer) to call it.

#126 made that false. `listApplications` and `rotateServiceToken` now take a `createPortalClient`, and the whole point of that split is that an instance session cannot stand in for a portal account: they are different users in different pools on different hosts. The file was not in #126's diff, so the comment survived the change it describes.

## What changed

The comment only. It now states what the constraint actually is and why the calls take a portal client rather than the active profile's.

## Changeset

None. This is a comment with no effect on shipped behaviour or on the published package.

## Verification

`npm run build` and `npm test` pass (640 passed, 4 skipped). The repo has no lint or format script.