### PR TITLE
feat: add seamless apps to list and inspect managed applications

### DIFF
--- a/.changeset/apps-command.md
+++ b/.changeset/apps-command.md
@@ -1,0 +1,13 @@
+---
+"seamless-cli": minor
+---
+
+Add `seamless apps`, so a portal account can see what it owns without opening the dashboard.
+`apps list` prints name, plan, status, and instance URL; `apps get <id>` adds the console URL,
+region, owners, trial expiry, and whether a service token has been issued (masked, never the live
+value). Both take `--json` and both require a portal session.
+
+Applications are now read through the portal's `instanceUrl`, which is derived from the service
+plan, rather than the stored `domain` column that goes stale when a trial is upgraded. Applications
+that have not finished provisioning are listed instead of being silently dropped. `init` is
+unchanged: it still reads `domain` and still considers only applications that have one.

--- a/.changeset/apps-command.md
+++ b/.changeset/apps-command.md
@@ -11,3 +11,5 @@ Applications are now read through the portal's `instanceUrl`, which is derived f
 plan, rather than the stored `domain` column that goes stale when a trial is upgraded. Applications
 that have not finished provisioning are listed instead of being silently dropped. `init` is
 unchanged: it still reads `domain` and still considers only applications that have one.
+
+`apps list` includes the application id, and `apps get` accepts a name or infra id as well as an id.

--- a/.changeset/apps-command.md
+++ b/.changeset/apps-command.md
@@ -12,4 +12,4 @@ plan, rather than the stored `domain` column that goes stale when a trial is upg
 that have not finished provisioning are listed instead of being silently dropped. `init` is
 unchanged: it still reads `domain` and still considers only applications that have one.
 
-`apps list` includes the application id, and `apps get` accepts a name or infra id as well as an id.
+`apps list` shows the infra id as the reference (falling back to the id before provisioning), and `apps get` accepts an id, a name, or an infra id.

--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ own source is never overwritten.
 ### Seeing your managed applications
 
 ```bash
-seamless apps list              # name, plan, status, instance URL
+seamless apps list              # id, name, plan, status, instance URL
 seamless apps list --json
 seamless apps get <id>          # detail for one application
+seamless apps get my-app        # a name or infra id works too
 seamless apps get <id> --json
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ own source is never overwritten.
 ### Seeing your managed applications
 
 ```bash
-seamless apps list              # id, name, plan, status, instance URL
+seamless apps list              # reference, name, plan, status, instance URL
 seamless apps list --json
 seamless apps get <id>          # detail for one application
 seamless apps get my-app        # a name or infra id works too

--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ Run inside an existing project (a non-empty directory) to wire it up in place: `
 `api/.env` when an `api` directory is present, otherwise it prints the values to set by hand. Your
 own source is never overwritten.
 
+### Seeing your managed applications
+
+```bash
+seamless apps list              # name, plan, status, instance URL
+seamless apps list --json
+seamless apps get <id>          # detail for one application
+seamless apps get <id> --json
+```
+
+`apps` uses the portal session, so it needs `seamless login` and never an instance profile.
+Applications the control plane has not finished provisioning are listed with `(provisioning)` in
+place of an instance URL.
+
+`apps get` reports whether a service token has been issued, showing the masked value and its issue
+date. The live token exists only at rotation time, so the control plane never re-shows it. Checking
+here first is worth doing before `init` connects a project, since connecting rotates the token and
+invalidates the old one.
+
 Escape hatches:
 
 - `seamless init --local` forces the self-hosted flow below, even when signed in.

--- a/src/commands/apps.test.ts
+++ b/src/commands/apps.test.ts
@@ -100,7 +100,12 @@ describe("apps list", () => {
 
     expect(paths[0]).toBe("http://localhost:3000/applications");
     const out = output();
+    expect(out).toContain("ID");
     expect(out).toContain("NAME");
+    // The id is what `apps get` and `init --app` take, so it has to be readable
+    // straight off the list.
+    expect(out).toContain("app-1");
+    expect(out).toContain("app-2");
     expect(out).toContain("Acme");
     expect(out).toContain("https://acme.seamlessauth.com");
     expect(out).toContain("Pending");
@@ -215,21 +220,79 @@ describe("apps get", () => {
     expect(JSON.parse(logSpy.mock.calls[0][0] as string).id).toBe("app-1");
   });
 
-  it("requires an id", async () => {
+  it("requires a reference", async () => {
     await expect(runApps(["get"])).rejects.toThrow("exit:1");
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Usage: seamless apps get <id>"),
+      expect.stringContaining("Usage: seamless apps get <id|name|infra-id>"),
     );
   });
 
-  it("reports a missing application", async () => {
-    const { client } = fakeClient([response(404, null)]);
+  it("falls back to matching a name when the id lookup 404s", async () => {
+    const { client, paths } = fakeClient([
+      response(404, null),
+      response(200, { applications: [acme, pending] }),
+    ]);
+    vi.mocked(createPortalClient).mockResolvedValue(client);
+
+    await runApps(["get", "acme"]);
+
+    expect(paths).toEqual([
+      "http://localhost:3000/applications/acme",
+      "http://localhost:3000/applications",
+    ]);
+    expect(output()).toContain("Acme");
+  });
+
+  it("matches an infra id", async () => {
+    const { client } = fakeClient([
+      response(404, null),
+      response(200, { applications: [{ ...acme, infraId: "acme-infra" }] }),
+    ]);
+    vi.mocked(createPortalClient).mockResolvedValue(client);
+
+    await runApps(["get", "ACME-INFRA"]);
+
+    expect(output()).toContain("Acme");
+  });
+
+  it("asks for an id when a name is ambiguous", async () => {
+    const { client } = fakeClient([
+      response(404, null),
+      response(200, {
+        applications: [acme, { ...acme, id: "app-9" }],
+      }),
+    ]);
+    vi.mocked(createPortalClient).mockResolvedValue(client);
+
+    await expect(runApps(["get", "Acme"])).rejects.toThrow("exit:1");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("matches 2 applications"),
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("app-1, app-9"),
+    );
+  });
+
+  it("reports a missing application when nothing matches", async () => {
+    const { client } = fakeClient([
+      response(404, null),
+      response(200, { applications: [acme] }),
+    ]);
     vi.mocked(createPortalClient).mockResolvedValue(client);
 
     await expect(runApps(["get", "ghost"])).rejects.toThrow("exit:1");
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('Managed application "ghost" was not found.'),
     );
+  });
+
+  it("does not fall back on a non-404 failure", async () => {
+    const { client, paths } = fakeClient([response(500, null)]);
+    vi.mocked(createPortalClient).mockResolvedValue(client);
+
+    await expect(runApps(["get", "app-1"])).rejects.toThrow("exit:1");
+    expect(paths).toHaveLength(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("500"));
   });
 });
 

--- a/src/commands/apps.test.ts
+++ b/src/commands/apps.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../core/authClient.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../core/authClient.js")>(
+      "../core/authClient.js",
+    );
+  return { ...actual, createPortalClient: vi.fn() };
+});
+
+import { createPortalClient, ReauthRequiredError } from "../core/authClient.js";
+import type { AuthClient } from "../core/authClient.js";
+import type { ApiResponse } from "../core/http.js";
+import { runApps } from "./apps.js";
+
+function response<T>(status: number, data: T | null): ApiResponse<T> {
+  return { ok: status >= 200 && status < 300, status, data, headers: new Headers() };
+}
+
+// The real portal.ts runs against this, so the tests cover the request paths and
+// the mapping as well as the printed output.
+function fakeClient(replies: ApiResponse<unknown>[]): {
+  client: AuthClient;
+  paths: string[];
+} {
+  const paths: string[] = [];
+  let i = 0;
+  const next = () => replies[Math.min(i++, replies.length - 1)];
+
+  const client = {
+    profile: { name: "__portal__", instanceUrl: "https://portal.example.com" },
+    request: async (path: string) => {
+      paths.push(path);
+      return next();
+    },
+    get: async (path: string) => {
+      paths.push(path);
+      return next();
+    },
+    post: async (path: string) => {
+      paths.push(path);
+      return next();
+    },
+  } as unknown as AuthClient;
+
+  return { client, paths };
+}
+
+const acme = {
+  id: "app-1",
+  name: "Acme",
+  instanceUrl: "https://acme.seamlessauth.com",
+  consoleUrl: "https://acme.seamlessauth.com/console",
+  infraId: "acme",
+  servicePlan: "mvp",
+  status: "deployed",
+  hostedRegion: "us-east-1",
+  devMode: false,
+  ownerEmail: ["dev@example.com"],
+  createdAt: "2026-07-01T00:00:00.000Z",
+  serviceTokenMetadata: {
+    maskedToken: "****abcd",
+    createdAt: "2026-07-02T00:00:00.000Z",
+  },
+};
+
+const pending = { id: "app-2", name: "Pending", status: "provisioning" };
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  process.env.SEAMLESS_PORTAL_API_URL = "http://localhost:3000";
+  vi.mocked(createPortalClient).mockReset();
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new Error(`exit:${code}`);
+  }) as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.SEAMLESS_PORTAL_API_URL;
+});
+
+function output(): string {
+  return logSpy.mock.calls.map((c) => c[0] as string).join("\n");
+}
+
+describe("apps list", () => {
+  it("prints a table and marks an application that is still provisioning", async () => {
+    const { client, paths } = fakeClient([
+      response(200, { applications: [acme, pending] }),
+    ]);
+    vi.mocked(createPortalClient).mockResolvedValue(client);
+
+    await runApps(["list"]);
+
+    expect(paths[0]).toBe("http://localhost:3000/applications");
+    const out = output();
+    expect(out).toContain("NAME");
+    expect(out).toContain("Acme");
+    expect(out).toContain("https://acme.seamlessauth.com");
+    expect(out).toContain("Pending");
+    expect(out).toContain("(provisioning)");
+    expect(out).toContain("2 applications.");
+  });
+
+  it("defaults to list when no subcommand is given", async () => {
+    const { client } = fakeClient([response(200, { applications: [acme] })]);
+    vi.mocked(createPortalClient).mockResolvedValue(client);
+
+    await runApps([]);
+
+    expect(output()).toContain("Acme");
+    expect(output()).toContain("1 application.");
+  });
+
+  it("points at the dashboard when the account owns nothing", async () => {
+    const { client } = fakeClient([response(200, { applications: [] })]);
+    vi.mocked(createPortalClient).mockResolvedValue(client);
+
+    await runApps(["list"]);
+
+    expect(output()).toContain("No managed applications.");
+    expect(output()).toContain("dashboard.seamlessauth.com");
+  });
+
+  it("emits mapped applications with --json", async () => {
+    const { client } = fakeClient([response(200, { applications: [acme] })]);
+    vi.mocked(createPortalClient).mockResolvedValue(client);
+
+    await runApps(["list", "--json"]);
+
+    const parsed = JSON.parse(logSpy.mock.calls[0][0] as string);
+    expect(parsed[0]).toMatchObject({
+      id: "app-1",
+      instanceUrl: "https://acme.seamlessauth.com",
+      hasServiceToken: true,
+    });
+    expect(output()).not.toContain("NAME");
+  });
+});
+
+describe("apps get", () => {
+  it("prints the detail view including masked token metadata", async () => {
+    const { client, paths } = fakeClient([
+      response(200, { application: acme }),
+    ]);
+    vi.mocked(createPortalClient).mockResolvedValue(client);
+
+    await runApps(["get", "app-1"]);
+
+    expect(paths[0]).toBe("http://localhost:3000/applications/app-1");
+    const out = output();
+    expect(out).toContain("Acme");
+    expect(out).toContain("us-east-1");
+    expect(out).toContain("dev@example.com");
+    expect(out).toContain("****abcd");
+    expect(out).toContain("https://acme.seamlessauth.com/console");
+    expect(out).toContain("off");
+  });
+
+  it("reports no token and a missing instance URL", async () => {
+    const { client } = fakeClient([response(200, { application: pending })]);
+    vi.mocked(createPortalClient).mockResolvedValue(client);
+
+    await runApps(["get", "app-2"]);
+
+    expect(output()).toContain("none issued");
+    expect(output()).toContain("(provisioning)");
+  });
+
+  it("falls back to a generic marker when the token metadata has no mask", async () => {
+    const { client } = fakeClient([
+      response(200, { application: { ...pending, serviceTokenMetadata: {} } }),
+    ]);
+    vi.mocked(createPortalClient).mockResolvedValue(client);
+
+    await runApps(["get", "app-2"]);
+
+    expect(output()).toContain("(issued)");
+  });
+
+  it("shows dev mode, frontend, and trial expiry for a trial application", async () => {
+    const { client } = fakeClient([
+      response(200, {
+        application: {
+          ...pending,
+          devMode: true,
+          servicePlan: "trial",
+          frontendUrl: "https://trial.example.com",
+          trialExpiresAt: "2026-08-01T00:00:00.000Z",
+        },
+      }),
+    ]);
+    vi.mocked(createPortalClient).mockResolvedValue(client);
+
+    await runApps(["get", "app-2"]);
+
+    const out = output();
+    expect(out).toContain("on");
+    expect(out).toContain("https://trial.example.com");
+    expect(out).toContain("2026-08-01T00:00:00.000Z");
+  });
+
+  it("emits the mapped application with --json", async () => {
+    const { client } = fakeClient([response(200, { application: acme })]);
+    vi.mocked(createPortalClient).mockResolvedValue(client);
+
+    await runApps(["get", "app-1", "--json"]);
+
+    expect(JSON.parse(logSpy.mock.calls[0][0] as string).id).toBe("app-1");
+  });
+
+  it("requires an id", async () => {
+    await expect(runApps(["get"])).rejects.toThrow("exit:1");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Usage: seamless apps get <id>"),
+    );
+  });
+
+  it("reports a missing application", async () => {
+    const { client } = fakeClient([response(404, null)]);
+    vi.mocked(createPortalClient).mockResolvedValue(client);
+
+    await expect(runApps(["get", "ghost"])).rejects.toThrow("exit:1");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Managed application "ghost" was not found.'),
+    );
+  });
+});
+
+describe("apps errors", () => {
+  it("tells a signed-out developer to log in", async () => {
+    vi.mocked(createPortalClient).mockRejectedValue(
+      new ReauthRequiredError("You are not signed in to the Seamless portal."),
+    );
+
+    await expect(runApps(["list"])).rejects.toThrow("exit:1");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("not signed in to the Seamless portal"),
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("rejects an unknown subcommand", async () => {
+    await expect(runApps(["destroy"])).rejects.toThrow("exit:1");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Unknown apps subcommand: destroy"),
+    );
+  });
+
+  it("propagates unexpected errors", async () => {
+    vi.mocked(createPortalClient).mockRejectedValue(new Error("disk on fire"));
+
+    await expect(runApps(["list"])).rejects.toThrow("disk on fire");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/apps.test.ts
+++ b/src/commands/apps.test.ts
@@ -46,8 +46,13 @@ function fakeClient(replies: ApiResponse<unknown>[]): {
   return { client, paths };
 }
 
+// Real UUIDs: `apps get` sends a UUID straight to the control plane and resolves
+// anything else against the list, so the id format decides which path runs.
+const ACME_ID = "11111111-1111-4111-8111-111111111111";
+const PENDING_ID = "22222222-2222-4222-8222-222222222222";
+
 const acme = {
-  id: "app-1",
+  id: ACME_ID,
   name: "Acme",
   instanceUrl: "https://acme.seamlessauth.com",
   consoleUrl: "https://acme.seamlessauth.com/console",
@@ -64,7 +69,8 @@ const acme = {
   },
 };
 
-const pending = { id: "app-2", name: "Pending", status: "provisioning" };
+// No infraId: not provisioned yet, so it has no short reference to show.
+const pending = { id: PENDING_ID, name: "Pending", status: "provisioning" };
 
 let logSpy: ReturnType<typeof vi.spyOn>;
 let errorSpy: ReturnType<typeof vi.spyOn>;
@@ -102,10 +108,11 @@ describe("apps list", () => {
     const out = output();
     expect(out).toContain("ID");
     expect(out).toContain("NAME");
-    // The id is what `apps get` and `init --app` take, so it has to be readable
-    // straight off the list.
-    expect(out).toContain("app-1");
-    expect(out).toContain("app-2");
+    // The reference is what `apps get` and `init --app` take, so it has to be
+    // readable straight off the list: the infra id when there is one, and the
+    // UUID for an application that has not been provisioned yet.
+    expect(out).toContain("acme");
+    expect(out).toContain(PENDING_ID);
     expect(out).toContain("Acme");
     expect(out).toContain("https://acme.seamlessauth.com");
     expect(out).toContain("Pending");
@@ -141,7 +148,8 @@ describe("apps list", () => {
 
     const parsed = JSON.parse(logSpy.mock.calls[0][0] as string);
     expect(parsed[0]).toMatchObject({
-      id: "app-1",
+      id: ACME_ID,
+      infraId: "acme",
       instanceUrl: "https://acme.seamlessauth.com",
       hasServiceToken: true,
     });
@@ -150,15 +158,15 @@ describe("apps list", () => {
 });
 
 describe("apps get", () => {
-  it("prints the detail view including masked token metadata", async () => {
+  it("sends a UUID straight to the control plane and prints the detail view", async () => {
     const { client, paths } = fakeClient([
       response(200, { application: acme }),
     ]);
     vi.mocked(createPortalClient).mockResolvedValue(client);
 
-    await runApps(["get", "app-1"]);
+    await runApps(["get", ACME_ID]);
 
-    expect(paths[0]).toBe("http://localhost:3000/applications/app-1");
+    expect(paths).toEqual([`http://localhost:3000/applications/${ACME_ID}`]);
     const out = output();
     expect(out).toContain("Acme");
     expect(out).toContain("us-east-1");
@@ -215,9 +223,9 @@ describe("apps get", () => {
     const { client } = fakeClient([response(200, { application: acme })]);
     vi.mocked(createPortalClient).mockResolvedValue(client);
 
-    await runApps(["get", "app-1", "--json"]);
+    await runApps(["get", ACME_ID, "--json"]);
 
-    expect(JSON.parse(logSpy.mock.calls[0][0] as string).id).toBe("app-1");
+    expect(JSON.parse(logSpy.mock.calls[0][0] as string).id).toBe(ACME_ID);
   });
 
   it("requires a reference", async () => {
@@ -227,40 +235,34 @@ describe("apps get", () => {
     );
   });
 
-  it("falls back to matching a name when the id lookup 404s", async () => {
+  it("resolves an infra id against the list, without a doomed lookup first", async () => {
     const { client, paths } = fakeClient([
-      response(404, null),
       response(200, { applications: [acme, pending] }),
     ]);
     vi.mocked(createPortalClient).mockResolvedValue(client);
 
-    await runApps(["get", "acme"]);
+    await runApps(["get", "ACME"]);
 
-    expect(paths).toEqual([
-      "http://localhost:3000/applications/acme",
-      "http://localhost:3000/applications",
-    ]);
+    // Only the list request: the control plane looks up by primary key, so
+    // asking it for an infra id could only 404.
+    expect(paths).toEqual(["http://localhost:3000/applications"]);
     expect(output()).toContain("Acme");
   });
 
-  it("matches an infra id", async () => {
+  it("resolves a name", async () => {
     const { client } = fakeClient([
-      response(404, null),
-      response(200, { applications: [{ ...acme, infraId: "acme-infra" }] }),
+      response(200, { applications: [acme, pending] }),
     ]);
     vi.mocked(createPortalClient).mockResolvedValue(client);
 
-    await runApps(["get", "ACME-INFRA"]);
+    await runApps(["get", "pending"]);
 
-    expect(output()).toContain("Acme");
+    expect(output()).toContain("Pending");
   });
 
-  it("asks for an id when a name is ambiguous", async () => {
+  it("asks for an id when a reference is ambiguous", async () => {
     const { client } = fakeClient([
-      response(404, null),
-      response(200, {
-        applications: [acme, { ...acme, id: "app-9" }],
-      }),
+      response(200, { applications: [acme, { ...acme, id: "app-9" }] }),
     ]);
     vi.mocked(createPortalClient).mockResolvedValue(client);
 
@@ -269,28 +271,32 @@ describe("apps get", () => {
       expect.stringContaining("matches 2 applications"),
     );
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("app-1, app-9"),
+      expect.stringContaining(`${ACME_ID}, app-9`),
     );
   });
 
-  it("reports a missing application when nothing matches", async () => {
-    const { client } = fakeClient([
-      response(404, null),
+  it("asks the control plane when nothing in the list matches", async () => {
+    const { client, paths } = fakeClient([
       response(200, { applications: [acme] }),
+      response(404, null),
     ]);
     vi.mocked(createPortalClient).mockResolvedValue(client);
 
     await expect(runApps(["get", "ghost"])).rejects.toThrow("exit:1");
+    expect(paths).toEqual([
+      "http://localhost:3000/applications",
+      "http://localhost:3000/applications/ghost",
+    ]);
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('Managed application "ghost" was not found.'),
     );
   });
 
-  it("does not fall back on a non-404 failure", async () => {
+  it("reports a non-404 failure without falling back", async () => {
     const { client, paths } = fakeClient([response(500, null)]);
     vi.mocked(createPortalClient).mockResolvedValue(client);
 
-    await expect(runApps(["get", "app-1"])).rejects.toThrow("exit:1");
+    await expect(runApps(["get", ACME_ID])).rejects.toThrow("exit:1");
     expect(paths).toHaveLength(1);
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("500"));
   });

--- a/src/commands/apps.ts
+++ b/src/commands/apps.ts
@@ -9,8 +9,8 @@ import {
   getApplication,
   listApplications,
   PortalError,
-  PortalNotFoundError,
   resolveAppInstanceUrl,
+  resolveAppRef,
   type PortalApp,
 } from "../core/portal.js";
 
@@ -68,10 +68,10 @@ async function appsList(rest: string[]): Promise<void> {
     return;
   }
 
-  // The id leads because it is the value you copy into `apps get` and
-  // `init --app`, and a UUID is not something you can retype from memory.
+  // The reference leads because it is the value you copy into `apps get` and
+  // `init --app`, neither of which you can retype from the name alone.
   const rows = apps.map((app) => [
-    app.id,
+    resolveAppRef(app),
     app.name,
     app.servicePlan ?? "-",
     app.status ?? "-",
@@ -105,34 +105,32 @@ async function appsGet(rest: string[]): Promise<void> {
   printApp(app);
 }
 
-// The control plane looks applications up by primary key only, but a developer
-// reading the list is as likely to reach for a name or an infra id. Try the id
-// first, then fall back to matching the list client-side.
-async function resolveApp(
-  client: AuthClient,
-  ref: string,
-): Promise<PortalApp> {
-  try {
-    return await getApplication(client, ref);
-  } catch (err) {
-    if (!(err instanceof PortalNotFoundError)) throw err;
-    return matchApplication(await listApplications(client), ref, err);
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// The control plane looks applications up by primary key only, but `apps list`
+// shows the infra id, so that is what a developer pastes. A UUID goes straight
+// to the endpoint; anything else is matched against the list rather than spending
+// a request that could only 404.
+async function resolveApp(client: AuthClient, ref: string): Promise<PortalApp> {
+  if (UUID.test(ref)) {
+    return getApplication(client, ref);
   }
+
+  const match = matchApplication(await listApplications(client), ref);
+  if (match) return match;
+
+  // Nothing matched by name or infra id. Ask the control plane anyway, so a
+  // future id format that is not a UUID still resolves (and 404s honestly).
+  return getApplication(client, ref);
 }
 
-function matchApplication(
-  apps: PortalApp[],
-  ref: string,
-  notFound: PortalNotFoundError,
-): PortalApp {
+function matchApplication(apps: PortalApp[], ref: string): PortalApp | null {
   const needle = ref.toLowerCase();
   const matches = apps.filter(
     (app) =>
       app.infraId?.toLowerCase() === needle ||
       app.name.toLowerCase() === needle,
   );
-
-  if (matches.length === 1) return matches[0];
 
   if (matches.length > 1) {
     throw new PortalError(
@@ -142,7 +140,7 @@ function matchApplication(
     );
   }
 
-  throw notFound;
+  return matches[0] ?? null;
 }
 
 function printApp(app: PortalApp): void {

--- a/src/commands/apps.ts
+++ b/src/commands/apps.ts
@@ -1,10 +1,15 @@
 import kleur from "kleur";
 
-import { createPortalClient, ReauthRequiredError } from "../core/authClient.js";
+import {
+  createPortalClient,
+  ReauthRequiredError,
+  type AuthClient,
+} from "../core/authClient.js";
 import {
   getApplication,
   listApplications,
   PortalError,
+  PortalNotFoundError,
   resolveAppInstanceUrl,
   type PortalApp,
 } from "../core/portal.js";
@@ -63,14 +68,17 @@ async function appsList(rest: string[]): Promise<void> {
     return;
   }
 
+  // The id leads because it is the value you copy into `apps get` and
+  // `init --app`, and a UUID is not something you can retype from memory.
   const rows = apps.map((app) => [
+    app.id,
     app.name,
     app.servicePlan ?? "-",
     app.status ?? "-",
     resolveAppInstanceUrl(app) ?? NOT_PROVISIONED,
   ]);
 
-  printTable(["NAME", "PLAN", "STATUS", "INSTANCE"], rows);
+  printTable(["ID", "NAME", "PLAN", "STATUS", "INSTANCE"], rows);
   console.log(
     kleur.dim(
       `\n${apps.length} application${apps.length === 1 ? "" : "s"}. Inspect one with: seamless apps get <id>`,
@@ -80,14 +88,14 @@ async function appsList(rest: string[]): Promise<void> {
 
 async function appsGet(rest: string[]): Promise<void> {
   const json = rest.includes("--json");
-  const id = rest.find((arg) => !arg.startsWith("--"));
-  if (!id) {
-    console.error(kleur.red("Usage: seamless apps get <id>"));
+  const ref = rest.find((arg) => !arg.startsWith("--"));
+  if (!ref) {
+    console.error(kleur.red("Usage: seamless apps get <id|name|infra-id>"));
     process.exit(1);
   }
 
   const client = await createPortalClient();
-  const app = await getApplication(client, id);
+  const app = await resolveApp(client, ref);
 
   if (json) {
     console.log(JSON.stringify(app, null, 2));
@@ -95,6 +103,46 @@ async function appsGet(rest: string[]): Promise<void> {
   }
 
   printApp(app);
+}
+
+// The control plane looks applications up by primary key only, but a developer
+// reading the list is as likely to reach for a name or an infra id. Try the id
+// first, then fall back to matching the list client-side.
+async function resolveApp(
+  client: AuthClient,
+  ref: string,
+): Promise<PortalApp> {
+  try {
+    return await getApplication(client, ref);
+  } catch (err) {
+    if (!(err instanceof PortalNotFoundError)) throw err;
+    return matchApplication(await listApplications(client), ref, err);
+  }
+}
+
+function matchApplication(
+  apps: PortalApp[],
+  ref: string,
+  notFound: PortalNotFoundError,
+): PortalApp {
+  const needle = ref.toLowerCase();
+  const matches = apps.filter(
+    (app) =>
+      app.infraId?.toLowerCase() === needle ||
+      app.name.toLowerCase() === needle,
+  );
+
+  if (matches.length === 1) return matches[0];
+
+  if (matches.length > 1) {
+    throw new PortalError(
+      `"${ref}" matches ${matches.length} applications. Use an id: ${matches
+        .map((app) => app.id)
+        .join(", ")}.`,
+    );
+  }
+
+  throw notFound;
 }
 
 function printApp(app: PortalApp): void {

--- a/src/commands/apps.ts
+++ b/src/commands/apps.ts
@@ -1,0 +1,144 @@
+import kleur from "kleur";
+
+import { createPortalClient, ReauthRequiredError } from "../core/authClient.js";
+import {
+  getApplication,
+  listApplications,
+  PortalError,
+  resolveAppInstanceUrl,
+  type PortalApp,
+} from "../core/portal.js";
+
+export async function runApps(args: string[]): Promise<void> {
+  const sub = args[0];
+  const rest = args.slice(1);
+
+  try {
+    switch (sub) {
+      case undefined:
+      case "list":
+        await appsList(rest);
+        return;
+      case "get":
+        await appsGet(rest);
+        return;
+      default:
+        console.error(kleur.red(`Unknown apps subcommand: ${sub}`));
+        console.log("Usage: seamless apps <list|get>");
+        process.exit(1);
+    }
+  } catch (err) {
+    reportPortalError(err);
+  }
+}
+
+function reportPortalError(err: unknown): never {
+  if (err instanceof ReauthRequiredError || err instanceof PortalError) {
+    console.error(kleur.red((err as Error).message));
+    process.exit(1);
+  }
+  throw err;
+}
+
+// Shown where an instance URL belongs for an application the control plane has
+// not finished provisioning, so an empty column never reads as a bug.
+const NOT_PROVISIONED = "(provisioning)";
+
+async function appsList(rest: string[]): Promise<void> {
+  const json = rest.includes("--json");
+  const client = await createPortalClient();
+  const apps = await listApplications(client);
+
+  if (json) {
+    console.log(JSON.stringify(apps, null, 2));
+    return;
+  }
+
+  if (apps.length === 0) {
+    console.log(kleur.dim("No managed applications."));
+    console.log(
+      kleur.dim("Create one at ") +
+        kleur.cyan("https://dashboard.seamlessauth.com"),
+    );
+    return;
+  }
+
+  const rows = apps.map((app) => [
+    app.name,
+    app.servicePlan ?? "-",
+    app.status ?? "-",
+    resolveAppInstanceUrl(app) ?? NOT_PROVISIONED,
+  ]);
+
+  printTable(["NAME", "PLAN", "STATUS", "INSTANCE"], rows);
+  console.log(
+    kleur.dim(
+      `\n${apps.length} application${apps.length === 1 ? "" : "s"}. Inspect one with: seamless apps get <id>`,
+    ),
+  );
+}
+
+async function appsGet(rest: string[]): Promise<void> {
+  const json = rest.includes("--json");
+  const id = rest.find((arg) => !arg.startsWith("--"));
+  if (!id) {
+    console.error(kleur.red("Usage: seamless apps get <id>"));
+    process.exit(1);
+  }
+
+  const client = await createPortalClient();
+  const app = await getApplication(client, id);
+
+  if (json) {
+    console.log(JSON.stringify(app, null, 2));
+    return;
+  }
+
+  printApp(app);
+}
+
+function printApp(app: PortalApp): void {
+  const line = (label: string, value: string) =>
+    console.log(kleur.dim(`${label}:`.padEnd(12)) + value);
+
+  line("Name", kleur.bold(app.name));
+  line("Id", app.id);
+  if (app.infraId) line("Infra id", app.infraId);
+  line("Plan", app.servicePlan ?? "-");
+  line("Status", app.status ?? "-");
+  if (app.hostedRegion) line("Region", app.hostedRegion);
+  if (app.devMode !== undefined) line("Dev mode", app.devMode ? "on" : "off");
+
+  line("Instance", resolveAppInstanceUrl(app) ?? kleur.dim(NOT_PROVISIONED));
+  if (app.consoleUrl) line("Console", app.consoleUrl);
+  if (app.frontendUrl) line("Frontend", app.frontendUrl);
+
+  if (app.ownerEmails.length) line("Owners", app.ownerEmails.join(", "));
+  if (app.trialExpiresAt) line("Trial ends", app.trialExpiresAt);
+  if (app.createdAt) line("Created", app.createdAt);
+
+  // Metadata only. A raw service token exists just once, at rotation time.
+  if (app.hasServiceToken) {
+    const masked = app.serviceToken?.maskedToken ?? "(issued)";
+    const issued = app.serviceToken?.createdAt;
+    line("Token", masked + (issued ? kleur.dim(`  issued ${issued}`) : ""));
+  } else {
+    line("Token", kleur.dim("none issued"));
+  }
+}
+
+function printTable(headers: string[], rows: string[][]): void {
+  const widths = headers.map((header, i) =>
+    Math.max(header.length, ...rows.map((row) => row[i].length)),
+  );
+
+  const render = (cells: string[]) =>
+    cells
+      .map((cell, i) => (i === cells.length - 1 ? cell : cell.padEnd(widths[i])))
+      .join("  ");
+
+  console.log(kleur.dim(render(headers)));
+  for (const row of rows) {
+    console.log(render(row));
+  }
+}

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -16,6 +16,7 @@ USAGE
   seamless verify [--api-only] [--filter=<flow>] [--keep-up]
   seamless profile <list|add|use|remove|login>
   seamless login [identifier] [--identifier <email>] [--local]
+  seamless apps <list|get>
   seamless whoami [--profile <name>]
   seamless logout [--all] [--profile <name>]
   seamless sessions [list]
@@ -84,6 +85,18 @@ COMMANDS
       • Requires the auth API to run outside production with
         ALLOW_UNCREDENTIALED_DELIVERY_SECRETS=true.
       • Point SEAMLESS_PORTAL_AUTH_URL at a local instance to develop against it.
+
+  apps <list|get>
+    Show the managed applications your portal account owns. Requires a portal
+    session (seamless login), not an instance profile.
+
+    apps list [--json]
+      • Table of name, plan, status, and instance URL
+      • Applications still provisioning are listed with (provisioning)
+
+    apps get <id> [--json]
+      • Detail for one application, including the console URL, owners, and
+        whether a service token has been issued (masked, never the live value)
 
   whoami
     Show the identity behind your portal session (sub, email, roles), alongside

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -91,7 +91,8 @@ COMMANDS
     session (seamless login), not an instance profile.
 
     apps list [--json]
-      • Table of id, name, plan, status, and instance URL
+      • Table of reference, name, plan, status, and instance URL
+      • The reference is the infra id, or the id before one is assigned
       • Applications still provisioning are listed with (provisioning)
 
     apps get <id|name|infra-id> [--json]

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -91,10 +91,10 @@ COMMANDS
     session (seamless login), not an instance profile.
 
     apps list [--json]
-      • Table of name, plan, status, and instance URL
+      • Table of id, name, plan, status, and instance URL
       • Applications still provisioning are listed with (provisioning)
 
-    apps get <id> [--json]
+    apps get <id|name|infra-id> [--json]
       • Detail for one application, including the console URL, owners, and
         whether a service token has been issued (masked, never the live value)
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -175,7 +175,7 @@ async function scaffoldManaged(
   // Resolve the target application before writing files, so a cancelled selection
   // or an authorization failure leaves nothing behind.
   const apps = await listApplications(client);
-  const app = await selectApplication(apps, opts.appId);
+  const app = await selectApplication(connectable(apps), opts.appId);
   if (!app) return;
 
   // Copy templates before rotating the service token. Rotation invalidates the
@@ -359,7 +359,7 @@ async function integrateExistingProject(
   }
 
   const apps = await listApplications(client);
-  const app = await selectApplication(apps, opts.appId);
+  const app = await selectApplication(connectable(apps), opts.appId);
   if (!app) return;
 
   const serviceToken = await issueServiceToken(client, app);
@@ -452,6 +452,15 @@ async function issueServiceToken(
     }
   }
   return rotateServiceToken(client, app.id);
+}
+
+type ConnectableApp = PortalApp & { domain: string };
+
+// listApplications reports applications that have not finished provisioning too,
+// because `seamless apps list` has to show them. Managed connect needs an auth
+// server to point at, so it keeps considering only the ones that have one.
+function connectable(apps: PortalApp[]): ConnectableApp[] {
+  return apps.filter((app): app is ConnectableApp => !!app.domain);
 }
 
 interface SelectedTemplate {

--- a/src/core/portal.test.ts
+++ b/src/core/portal.test.ts
@@ -6,8 +6,10 @@ import type { Profile } from "./config.js";
 import {
   DEFAULT_PORTAL_API_URL,
   PortalError,
+  getApplication,
   getPortalApiUrl,
   listApplications,
+  resolveAppInstanceUrl,
   rotateServiceToken,
 } from "./portal.js";
 
@@ -96,11 +98,23 @@ describe("listApplications", () => {
             id: "app-1",
             name: "Acme",
             domain: "https://acme.seamlessauth.com",
+            instanceUrl: "https://acme.seamlessauth.com/infra-1",
+            consoleUrl: "https://acme.seamlessauth.com/infra-1/console",
             infraId: "acme",
-            serviceTokenMetadata: { maskedToken: "****abcd" },
+            servicePlan: "mvp",
+            status: "deployed",
+            hostedRegion: "us-east-1",
+            devMode: false,
+            ownerEmail: ["dev@example.com", 42],
+            createdAt: "2026-07-01T00:00:00.000Z",
+            serviceTokenMetadata: {
+              maskedToken: "****abcd",
+              createdAt: "2026-07-02T00:00:00.000Z",
+            },
           },
           { id: "app-2", name: "Beta", domain: "https://beta.seamlessauth.com" },
           { id: "no-domain" },
+          { name: "no id at all" },
         ],
       }),
     ]);
@@ -111,15 +125,48 @@ describe("listApplications", () => {
       method: "GET",
       path: "http://localhost:5001/applications",
     });
-    expect(apps).toHaveLength(2);
+
+    // An application without a URL is still provisioning and must be listed;
+    // only one without an id is unusable.
+    expect(apps).toHaveLength(3);
     expect(apps[0]).toMatchObject({
       id: "app-1",
       name: "Acme",
+      instanceUrl: "https://acme.seamlessauth.com/infra-1",
       domain: "https://acme.seamlessauth.com",
+      consoleUrl: "https://acme.seamlessauth.com/infra-1/console",
       infraId: "acme",
+      servicePlan: "mvp",
+      status: "deployed",
+      hostedRegion: "us-east-1",
+      devMode: false,
+      ownerEmails: ["dev@example.com"],
       hasServiceToken: true,
+      serviceToken: {
+        maskedToken: "****abcd",
+        createdAt: "2026-07-02T00:00:00.000Z",
+      },
     });
     expect(apps[1].hasServiceToken).toBe(false);
+    expect(apps[1].serviceToken).toBeUndefined();
+    expect(apps[2].name).toBe("no-domain");
+    expect(apps[2].ownerEmails).toEqual([]);
+  });
+
+  it("accepts a single owner email as a string", async () => {
+    const { client } = fakeClient([
+      response(200, {
+        applications: [{ id: "app-1", ownerEmail: "solo@example.com" }],
+      }),
+    ]);
+
+    const apps = await listApplications(client);
+    expect(apps[0].ownerEmails).toEqual(["solo@example.com"]);
+  });
+
+  it("returns an empty list when the payload has no applications array", async () => {
+    const { client } = fakeClient([response(200, {})]);
+    await expect(listApplications(client)).resolves.toEqual([]);
   });
 
   it("treats a 401 as an authorization failure", async () => {
@@ -130,6 +177,89 @@ describe("listApplications", () => {
   it("reports other failures with the status code", async () => {
     const { client } = fakeClient([response(500, null)]);
     await expect(listApplications(client)).rejects.toThrow(/500/);
+  });
+});
+
+describe("resolveAppInstanceUrl", () => {
+  const base = { id: "a", name: "A", ownerEmails: [], hasServiceToken: false };
+
+  it("prefers instanceUrl over the legacy domain column", () => {
+    expect(
+      resolveAppInstanceUrl({
+        ...base,
+        instanceUrl: "https://acme.seamlessauth.com/infra-1",
+        domain: "https://acme.seamlessauth.com",
+      }),
+    ).toBe("https://acme.seamlessauth.com/infra-1");
+  });
+
+  it("falls back to domain, and is undefined when neither is set", () => {
+    expect(
+      resolveAppInstanceUrl({ ...base, domain: "https://acme.seamlessauth.com" }),
+    ).toBe("https://acme.seamlessauth.com");
+    expect(resolveAppInstanceUrl(base)).toBeUndefined();
+  });
+});
+
+describe("getApplication", () => {
+  beforeEach(() => {
+    process.env.SEAMLESS_PORTAL_API_URL = "http://localhost:5001";
+  });
+  afterEach(() => {
+    delete process.env.SEAMLESS_PORTAL_API_URL;
+  });
+
+  it("requests one application and maps it", async () => {
+    const { client, calls } = fakeClient([
+      response(200, {
+        message: "success",
+        application: { id: "app 1", name: "Acme", status: "deployed" },
+      }),
+    ]);
+
+    const app = await getApplication(client, "app 1");
+
+    expect(calls[0]).toEqual({
+      method: "GET",
+      path: "http://localhost:5001/applications/app%201",
+    });
+    expect(app).toMatchObject({ id: "app 1", name: "Acme", status: "deployed" });
+  });
+
+  it("maps a 404 to a not-found error", async () => {
+    const { client } = fakeClient([response(404, null)]);
+    await expect(getApplication(client, "missing")).rejects.toThrow(
+      /was not found/,
+    );
+  });
+
+  it("treats a 401 or 403 as an authorization failure", async () => {
+    const forbidden = fakeClient([response(403, null)]);
+    await expect(
+      getApplication(forbidden.client, "app-1"),
+    ).rejects.toBeInstanceOf(PortalError);
+
+    const unauth = fakeClient([response(401, null)]);
+    await expect(getApplication(unauth.client, "app-1")).rejects.toBeInstanceOf(
+      PortalError,
+    );
+  });
+
+  it("reports other failures with the status code", async () => {
+    const { client } = fakeClient([response(500, null)]);
+    await expect(getApplication(client, "app-1")).rejects.toThrow(/500/);
+  });
+
+  it("rejects a payload without a usable application", async () => {
+    const missing = fakeClient([response(200, { message: "success" })]);
+    await expect(getApplication(missing.client, "app-1")).rejects.toThrow(
+      /unexpected response/,
+    );
+
+    const idless = fakeClient([response(200, { application: { name: "x" } })]);
+    await expect(getApplication(idless.client, "app-1")).rejects.toThrow(
+      /unexpected response/,
+    );
   });
 });
 

--- a/src/core/portal.ts
+++ b/src/core/portal.ts
@@ -21,20 +21,44 @@ export class PortalError extends Error {
   }
 }
 
-// A managed application as the CLI needs it. `domain` is the application's own
-// managed auth instance URL (https://<infraId>.seamlessauth.com), which the
-// scaffold points its AUTH_SERVER_URL at. `hasServiceToken` reflects whether a
-// service token was ever issued, so init can confirm before rotating and
-// invalidating one that a deployed app may still be using.
+// A managed application as the CLI needs it, mapped from the portal's
+// serializeApplication payload (documented there as a CLI-facing contract).
+//
+// `instanceUrl` is where the tenant's auth actually answers; the portal derives
+// it from the service plan. `domain` is the stored column it superseded, kept
+// because it goes stale when a trial is upgraded and its tenant moves zones, so
+// prefer instanceUrl and read both through resolveAppInstanceUrl.
+//
+// Both are optional: an application that has not finished provisioning has
+// neither, and a list command has to be able to show it.
+//
+// `hasServiceToken` reflects whether a token was ever issued, so init can
+// confirm before rotating and invalidating one a deployed app may still be using.
 export interface PortalApp {
   id: string;
   name: string;
-  domain: string;
+  instanceUrl?: string;
+  domain?: string;
+  consoleUrl?: string;
   infraId?: string;
   frontendUrl?: string;
   servicePlan?: string;
   status?: string;
+  hostedRegion?: string;
+  devMode?: boolean;
+  ownerEmails: string[];
+  trialExpiresAt?: string;
+  createdAt?: string;
   hasServiceToken: boolean;
+  // Metadata only. The control plane returns a raw token exclusively at
+  // rotation time, so there is never a live secret to show here.
+  serviceToken?: { maskedToken?: string; createdAt?: string };
+}
+
+// Where this application's auth answers, or undefined while it is still
+// provisioning.
+export function resolveAppInstanceUrl(app: PortalApp): string | undefined {
+  return app.instanceUrl ?? app.domain;
 }
 
 function str(raw: Record<string, unknown>, key: string): string | undefined {
@@ -42,20 +66,47 @@ function str(raw: Record<string, unknown>, key: string): string | undefined {
   return typeof value === "string" && value ? value : undefined;
 }
 
+function strList(raw: Record<string, unknown>, key: string): string[] {
+  const value = raw[key];
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === "string");
+  }
+  return typeof value === "string" && value ? [value] : [];
+}
+
+function toServiceToken(
+  raw: Record<string, unknown>,
+): PortalApp["serviceToken"] {
+  const meta = raw.serviceTokenMetadata;
+  if (!meta || typeof meta !== "object") return undefined;
+  const record = meta as Record<string, unknown>;
+  return {
+    maskedToken: str(record, "maskedToken"),
+    createdAt: str(record, "createdAt"),
+  };
+}
+
 function toApp(raw: Record<string, unknown>): PortalApp | null {
   const id = str(raw, "id");
-  const domain = str(raw, "domain");
-  if (!id || !domain) return null;
+  if (!id) return null;
 
   return {
     id,
     name: str(raw, "name") ?? id,
-    domain,
+    instanceUrl: str(raw, "instanceUrl"),
+    domain: str(raw, "domain"),
+    consoleUrl: str(raw, "consoleUrl"),
     infraId: str(raw, "infraId"),
     frontendUrl: str(raw, "frontendUrl"),
     servicePlan: str(raw, "servicePlan"),
     status: str(raw, "status"),
+    hostedRegion: str(raw, "hostedRegion"),
+    devMode: typeof raw.devMode === "boolean" ? raw.devMode : undefined,
+    ownerEmails: strList(raw, "ownerEmail"),
+    trialExpiresAt: str(raw, "trialExpiresAt"),
+    createdAt: str(raw, "createdAt"),
     hasServiceToken: raw.serviceTokenMetadata != null,
+    serviceToken: toServiceToken(raw),
   };
 }
 
@@ -81,6 +132,40 @@ export async function listApplications(client: AuthClient): Promise<PortalApp[]>
     .filter((a): a is Record<string, unknown> => !!a && typeof a === "object")
     .map(toApp)
     .filter((a): a is PortalApp => a !== null);
+}
+
+export async function getApplication(
+  client: AuthClient,
+  appId: string,
+): Promise<PortalApp> {
+  const url = joinUrl(
+    getPortalApiUrl(),
+    `/applications/${encodeURIComponent(appId)}`,
+  );
+  const res = await client.get<{ application?: unknown }>(url);
+
+  if (res.status === 401 || res.status === 403) {
+    throw unauthorized("read this application");
+  }
+  if (res.status === 404) {
+    throw new PortalError(`Managed application "${appId}" was not found.`);
+  }
+  if (!res.ok) {
+    throw new PortalError(`Could not load application "${appId}" (${res.status}).`);
+  }
+
+  const raw = res.data?.application;
+  const app =
+    raw && typeof raw === "object"
+      ? toApp(raw as Record<string, unknown>)
+      : null;
+  if (!app) {
+    throw new PortalError(
+      `The control plane returned an unexpected response for "${appId}".`,
+    );
+  }
+
+  return app;
 }
 
 // Issues (rotates) the application's service token. The control plane only ever

--- a/src/core/portal.ts
+++ b/src/core/portal.ts
@@ -21,6 +21,15 @@ export class PortalError extends Error {
   }
 }
 
+// Split out so a caller can retry a lookup by another reference (a name or infra
+// id) without matching on message text.
+export class PortalNotFoundError extends PortalError {
+  constructor(message: string) {
+    super(message);
+    this.name = "PortalNotFoundError";
+  }
+}
+
 // A managed application as the CLI needs it, mapped from the portal's
 // serializeApplication payload (documented there as a CLI-facing contract).
 //
@@ -148,7 +157,7 @@ export async function getApplication(
     throw unauthorized("read this application");
   }
   if (res.status === 404) {
-    throw new PortalError(`Managed application "${appId}" was not found.`);
+    throw new PortalNotFoundError(`Managed application "${appId}" was not found.`);
   }
   if (!res.ok) {
     throw new PortalError(`Could not load application "${appId}" (${res.status}).`);
@@ -186,7 +195,7 @@ export async function rotateServiceToken(
     throw unauthorized("issue a service token");
   }
   if (res.status === 404) {
-    throw new PortalError(`Managed application "${appId}" was not found.`);
+    throw new PortalNotFoundError(`Managed application "${appId}" was not found.`);
   }
   if (!res.ok || !res.data?.serviceToken) {
     throw new PortalError(`Could not issue a service token (${res.status}).`);

--- a/src/core/portal.ts
+++ b/src/core/portal.ts
@@ -70,6 +70,14 @@ export function resolveAppInstanceUrl(app: PortalApp): string | undefined {
   return app.instanceUrl ?? app.domain;
 }
 
+// The shortest reference that still identifies the application, for display and
+// for pasting into `apps get` or `init --app`. Both accept an infra id, and it
+// is far easier to read than the UUID primary key. Applications that have not
+// been provisioned have no infra id yet, so they fall back to the id.
+export function resolveAppRef(app: PortalApp): string {
+  return app.infraId ?? app.id;
+}
+
 function str(raw: Record<string, unknown>, key: string): string | undefined {
   const value = raw[key];
   return typeof value === "string" && value ? value : undefined;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -17,6 +17,7 @@ vi.mock("./commands/sessions.js", () => ({ runSessions: vi.fn() }));
 vi.mock("./commands/config.js", () => ({ runConfig: vi.fn() }));
 vi.mock("./commands/users.js", () => ({ runUsers: vi.fn() }));
 vi.mock("./commands/org.js", () => ({ runOrg: vi.fn() }));
+vi.mock("./commands/apps.js", () => ({ runApps: vi.fn() }));
 
 const flush = () => new Promise((r) => setImmediate(r));
 
@@ -108,6 +109,7 @@ describe("index dispatcher", () => {
     ["config", "./commands/config.js", "runConfig"],
     ["users", "./commands/users.js", "runUsers"],
     ["org", "./commands/org.js", "runOrg"],
+    ["apps", "./commands/apps.js", "runApps"],
   ])("dispatches %s with the remaining args", async (cmd, modPath, fnName) => {
     await dispatch([cmd, "sub", "--flag"]);
     const mod = (await import(/* @vite-ignore */ modPath)) as Record<string, ReturnType<typeof vi.fn>>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { runSessions } from "./commands/sessions.js";
 import { runConfig } from "./commands/config.js";
 import { runUsers } from "./commands/users.js";
 import { runOrg } from "./commands/org.js";
+import { runApps } from "./commands/apps.js";
 
 export const VERSION = pkg.version;
 const args = process.argv.slice(2);
@@ -108,6 +109,11 @@ async function main() {
 
   if (command === "org") {
     await runOrg(args.slice(1));
+    return;
+  }
+
+  if (command === "apps") {
+    await runApps(args.slice(1));
     return;
   }
 

--- a/src/prompts/appSelect.ts
+++ b/src/prompts/appSelect.ts
@@ -1,6 +1,6 @@
 import { select, isCancel, cancel } from "@clack/prompts";
 
-import type { PortalApp } from "../core/portal.js";
+import { resolveAppInstanceUrl, type PortalApp } from "../core/portal.js";
 
 export class NoApplicationsError extends Error {
   constructor() {
@@ -14,10 +14,12 @@ export class NoApplicationsError extends Error {
 // Resolves which managed application the scaffold connects to. `--app` matches an
 // id or infra id; a single application is auto-selected; otherwise the developer
 // picks. Returns null only when an interactive selection is cancelled.
-export async function selectApplication(
-  apps: PortalApp[],
+// Generic over the app type so a caller that has already narrowed to applications
+// with a resolvable instance URL keeps that guarantee on the selected one.
+export async function selectApplication<T extends PortalApp>(
+  apps: T[],
   preselectId?: string,
-): Promise<PortalApp | null> {
+): Promise<T | null> {
   if (apps.length === 0) {
     throw new NoApplicationsError();
   }
@@ -36,7 +38,9 @@ export async function selectApplication(
   }
 
   if (apps.length === 1) {
-    console.log(`Managed application: ${apps[0].name} (${apps[0].domain})`);
+    console.log(
+      `Managed application: ${apps[0].name} (${resolveAppInstanceUrl(apps[0])})`,
+    );
     return apps[0];
   }
 
@@ -45,7 +49,7 @@ export async function selectApplication(
     options: apps.map((a) => ({
       value: a.id,
       label: a.name,
-      hint: a.domain,
+      hint: resolveAppInstanceUrl(a),
     })),
   });
 


### PR DESCRIPTION
Closes #128. Builds on #126.

Adds `seamless apps`, so a portal account can see what it owns without opening the dashboard.

```bash
seamless apps list [--json]
seamless apps get <id> [--json]
```

`list` prints name, plan, status, and instance URL. `get` adds the console URL, region, dev mode,
owners, trial expiry, and whether a service token has been issued. Both go through
`createPortalClient`, so they require a portal session and never fall back to an instance profile.

## Why now

The only place the CLI read applications was inside `init`, mid-scaffold. So there was no way to
check whether an application had finished provisioning, or whether it already had a service token,
before `init` rotated that token and invalidated the old one. `apps get` answers that question
before the destructive step rather than during it.

## Contract corrections

Two things `toApp` got wrong, both surfaced while reading the portal's serializer:

- **It read `domain`.** The portal marks that field as kept "only for compatibility with clients
  that predate `instanceUrl`", and `resolveInstanceUrl` derives the real URL from the service plan
  because the stored column "goes stale the moment a trial is upgraded and its tenant moves out of
  the trial zone". So `domain` is wrong for any upgraded trial, and for path-routed paid tenants it
  drops the path. Mapping now prefers `instanceUrl`, via a `resolveAppInstanceUrl` helper.
- **It dropped applications without a `domain`.** That hid anything still provisioning, which is
  exactly what a list command should show. `toApp` now requires only an `id`, and both URL fields
  are optional.

`PortalApp` also carries the fields the detail view needs: `consoleUrl`, `hostedRegion`, `devMode`,
`ownerEmails`, `trialExpiresAt`, `createdAt`, and service token metadata.

## init is unchanged

Deliberately. A new `connectable()` filter restricts `init` to applications that have a `domain`,
which is exactly what `toApp` did before, and it still reads `domain` for `AUTH_SERVER_URL`.

Switching `init` to `instanceUrl` is worth doing but is its own change, because it has a wrinkle:
in a local portal (`NODE_ENV !== 'production'`, no real infra) `resolveInstanceUrl` returns the
portal's own `AUTH_SERVER_URL`, typically `http://seamless-auth:5312`. That is a container-internal
hostname, which `normalizeInstanceUrl` rejects and which is not reachable from the developer's
machine anyway. Solving that inside a listing feature would have buried it.

`selectApplication` is now generic over the app type so the narrowing from `connectable()` survives
selection, which is what keeps `app.domain` non-optional at the call site.

## Note on --json

Emits the CLI's mapped `PortalApp` objects, not the raw portal payload (the issue said raw). The
mapped shape is the one this repo tests and controls, and it carries `hasServiceToken`, which the
raw payload only implies. Say the word if you'd rather have the passthrough.

## Testing

`npm run build` and `npm test` pass (664 passed, 4 skipped). `npm run coverage` holds: 99.34% lines,
96.28% branches, 99.66% functions, with `portal.ts` and `index.ts` at 100%.

`apps.test.ts` mocks only `createPortalClient` and lets the real `portal.ts` run against a fake
client, so the tests cover request paths and mapping as well as the printed output: the table, the
`(provisioning)` marker, the empty-account message, `--json` on both subcommands, masked token
metadata, a missing id, a 404, and the signed-out path.

Not yet run against the live portal.
