### PR TITLE
fix: require init to scaffold, and never leave a project directory behind

### DIFF
--- a/.changeset/scaffold-cancellation.md
+++ b/.changeset/scaffold-cancellation.md
@@ -1,0 +1,21 @@
+---
+"seamless-cli": minor
+---
+
+Scaffolding now requires `init`. An unrecognized command reports itself and exits instead of being
+treated as a project name, so `seamless verfy` no longer silently creates a directory called
+`verfy` and drops into the interactive scaffold. The error names `seamless init <name>` for anyone
+who was using the old shortcut.
+
+Ctrl-C is handled everywhere. Clack answers an interrupted prompt with a symbol, which several
+prompts cast straight to a string; that surfaced as a `TypeError` mid-scaffold, or as "Selected
+template Symbol(...) is not in the registry". Every prompt in init, the OAuth setup, the managed
+application picker, and `bootstrap-admin` now cancels cleanly and exits 130.
+
+`init` no longer leaves a project directory behind. Any failure or cancellation after the directory
+is created removes it, including a Ctrl-C during a download or a git clone, so a retry is not
+blocked by "Directory already exists". Only a directory the command itself created is ever removed,
+never an existing one and never the working directory.
+
+Declining the service token rotation prompt, or cancelling the application picker, now cancels the
+whole command rather than returning quietly part-way through.

--- a/resources/coverage-badge.svg
+++ b/resources/coverage-badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 99.3%">
-  <title>coverage: 99.3%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 99.4%">
+  <title>coverage: 99.4%</title>
   <linearGradient id="smooth" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -17,7 +17,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="33" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="33" y="14">coverage</text>
-    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">99.3%</text>
-    <text x="88.5" y="14">99.3%</text>
+    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">99.4%</text>
+    <text x="88.5" y="14">99.4%</text>
   </g>
 </svg>

--- a/src/commands/bootstrapAdmin.test.ts
+++ b/src/commands/bootstrapAdmin.test.ts
@@ -7,13 +7,18 @@ vi.mock("../core/bootstrapSecret.js", () => ({
   resolveBootstrapSecret: vi.fn(),
 }));
 
-vi.mock("@clack/prompts", () => ({
-  intro: vi.fn(),
-  outro: vi.fn(),
-  text: vi.fn(),
-  confirm: vi.fn(),
-  spinner: vi.fn(),
-}));
+vi.mock("@clack/prompts", () => {
+  const CANCEL = Symbol("cancel");
+  return {
+    CANCEL,
+    intro: vi.fn(),
+    outro: vi.fn(),
+    text: vi.fn(),
+    confirm: vi.fn(),
+    spinner: vi.fn(),
+    isCancel: (value: unknown) => value === CANCEL,
+  };
+});
 
 import { intro, outro, text, confirm, spinner } from "@clack/prompts";
 

--- a/src/commands/bootstrapAdmin.ts
+++ b/src/commands/bootstrapAdmin.ts
@@ -1,6 +1,7 @@
 import { intro, outro, text, confirm, spinner } from "@clack/prompts";
 import kleur from "kleur";
 import { extractFlag } from "../core/args.js";
+import { orCancel } from "../core/cancel.js";
 import { resolveBootstrapSecret } from "../core/bootstrapSecret.js";
 
 const DEFAULT_API_URL = "http://localhost:3000";
@@ -25,21 +26,25 @@ export async function runBootstrapAdmin(args: string[] = []) {
   let email = rest.find((a) => !a.startsWith("-"));
 
   if (!email) {
-    email = (await text({
-      message: "Admin email address",
-      placeholder: "admin@example.com",
-      validate: (value) => {
-        if (!value || !value.includes("@")) {
-          return "Enter a valid email address";
-        }
-      },
-    })) as string;
+    email = orCancel(
+      await text({
+        message: "Admin email address",
+        placeholder: "admin@example.com",
+        validate: (value) => {
+          if (!value || !value.includes("@")) {
+            return "Enter a valid email address";
+          }
+        },
+      }),
+    ) as string;
   }
 
-  const proceed = await confirm({
-    message: "Create bootstrap admin invite?",
-    initialValue: true,
-  });
+  const proceed = orCancel(
+    await confirm({
+      message: "Create bootstrap admin invite?",
+      initialValue: true,
+    }),
+  );
 
   if (!proceed) {
     outro("Cancelled.");
@@ -59,13 +64,15 @@ export async function runBootstrapAdmin(args: string[] = []) {
       "This may happen if the project is not initialized locally or running in production.",
     );
 
-    secret = (await text({
-      message: "Bootstrap secret",
-      placeholder: "Enter your bootstrap secret",
-      validate: (value) => {
-        if (!value) return "Bootstrap secret is required";
-      },
-    })) as string;
+    secret = orCancel(
+      await text({
+        message: "Bootstrap secret",
+        placeholder: "Enter your bootstrap secret",
+        validate: (value) => {
+          if (!value) return "Bootstrap secret is required";
+        },
+      }),
+    ) as string;
   }
 
   const s = spinner();

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -201,14 +201,6 @@ COMMANDS
 
 ────────────────────────────────────────────
 
-BEHAVIOR
-
-  seamless <project-name>
-
-    • Shortcut for: seamless init <project-name>
-
-────────────────────────────────────────────
-
 GETTING STARTED
 
   1. seamless init
@@ -239,9 +231,6 @@ EXAMPLES
 
   seamless init --oauth my-app
     → Create ./my-app from the OAuth example starter
-
-  seamless my-app
-    → Shortcut for init
 
   seamless check
     → Validate your project

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -24,6 +24,7 @@ import { listApplications, rotateServiceToken } from "../core/portal.js";
 import { selectApplication } from "../prompts/appSelect.js";
 import { parseEnv, writeEnv } from "../core/env.js";
 
+import { CancelledError } from "../core/cancel.js";
 import { runCLI } from "./init.js";
 
 // Defensive: templates.ts transitively imports ../index.js (which runs main() at
@@ -35,6 +36,7 @@ vi.mock("fs", () => {
     existsSync: vi.fn(),
     mkdirSync: vi.fn(),
     readdirSync: vi.fn(),
+    rmSync: vi.fn(),
   };
   return { default: fns, ...fns };
 });
@@ -218,6 +220,110 @@ describe("runCLI directory handling", () => {
 
     expect(fs.mkdirSync).toHaveBeenCalledWith("/work/myapp");
     expect(out()).toContain("Creating project in /work/myapp");
+    expect(fs.rmSync).not.toHaveBeenCalled();
+  });
+
+  // A husk left behind by a failed attempt makes the retry fail with
+  // "Directory already exists", which is the actual bug developers hit.
+  it("discards the directory it created when the scaffold fails", async () => {
+    vi.mocked(createPortalClient).mockRejectedValue(
+      new ReauthRequiredError("no session"),
+    );
+    vi.mocked(openTemplateSource).mockRejectedValue(new Error("registry 500"));
+
+    await expect(runCLI("myapp", [])).rejects.toThrow("registry 500");
+
+    expect(fs.rmSync).toHaveBeenCalledWith("/work/myapp", {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  it("discards the directory it created when a prompt is cancelled", async () => {
+    vi.mocked(createPortalClient).mockRejectedValue(
+      new ReauthRequiredError("no session"),
+    );
+    vi.mocked(openTemplateSource).mockResolvedValue(makeSource() as never);
+    vi.mocked(runProjectSetupPrompts).mockRejectedValue(new CancelledError());
+
+    await expect(runCLI("myapp", [])).rejects.toBeInstanceOf(CancelledError);
+
+    expect(fs.rmSync).toHaveBeenCalledWith("/work/myapp", {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  // Without a project name the target is the developer's own working directory,
+  // which this command must never remove.
+  it("never removes the working directory when no name was given", async () => {
+    vi.mocked(createPortalClient).mockRejectedValue(
+      new ReauthRequiredError("no session"),
+    );
+    vi.mocked(openTemplateSource).mockRejectedValue(new Error("registry 500"));
+
+    await expect(runCLI(undefined, [])).rejects.toThrow("registry 500");
+
+    expect(fs.rmSync).not.toHaveBeenCalled();
+  });
+
+  it("leaves an existing directory alone when it refuses to scaffold", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+
+    await expect(runCLI("myapp")).rejects.toThrow(/already exists/);
+
+    expect(fs.rmSync).not.toHaveBeenCalled();
+  });
+
+  // Ctrl-C during a download or a git clone is a real signal, not a cancelled
+  // prompt, so it has to be caught before the process ends.
+  it("discards the directory when interrupted outside a prompt", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("exit:130");
+    }) as never);
+    vi.mocked(createPortalClient).mockRejectedValue(
+      new ReauthRequiredError("no session"),
+    );
+    vi.mocked(openTemplateSource).mockImplementation(async () => {
+      const listeners = process.listeners("SIGINT");
+      const onInterrupt = listeners[listeners.length - 1] as () => void;
+      expect(() => onInterrupt()).toThrow("exit:130");
+      throw new Error("interrupted");
+    });
+
+    await expect(runCLI("myapp", [])).rejects.toThrow("interrupted");
+
+    expect(fs.rmSync).toHaveBeenCalledWith("/work/myapp", {
+      recursive: true,
+      force: true,
+    });
+    expect(exitSpy).toHaveBeenCalledWith(130);
+  });
+
+  it("survives a directory that cannot be removed", async () => {
+    vi.mocked(createPortalClient).mockRejectedValue(
+      new ReauthRequiredError("no session"),
+    );
+    vi.mocked(openTemplateSource).mockRejectedValue(new Error("registry 500"));
+    vi.mocked(fs.rmSync).mockImplementation(() => {
+      throw new Error("permission denied");
+    });
+
+    // The scaffold failure is what the developer needs to see, not a cleanup
+    // error stacked on top of it.
+    await expect(runCLI("myapp", [])).rejects.toThrow("registry 500");
+  });
+
+  it("removes the interrupt handler once the scaffold finishes", async () => {
+    const before = process.listenerCount("SIGINT");
+    vi.mocked(createPortalClient).mockRejectedValue(
+      new ReauthRequiredError("no session"),
+    );
+    vi.mocked(openTemplateSource).mockRejectedValue(new Error("registry 500"));
+
+    await expect(runCLI("myapp", [])).rejects.toThrow("registry 500");
+
+    expect(process.listenerCount("SIGINT")).toBe(before);
   });
 });
 
@@ -627,10 +733,13 @@ describe("scaffoldManaged", () => {
     vi.mocked(selectApplication).mockResolvedValue(existing as never);
     vi.mocked(confirm).mockResolvedValue(false as never);
 
-    await runCLI(undefined, []);
+    // Declining cancels the command rather than returning quietly, so init can
+    // discard anything it created.
+    await expect(runCLI(undefined, [])).rejects.toThrow(
+      "Cancelled. No token was issued.",
+    );
 
     expect(rotateServiceToken).not.toHaveBeenCalled();
-    expect(out()).toContain("Cancelled. No token was issued.");
     expect(printManagedSuccessOutput).not.toHaveBeenCalled();
   });
 
@@ -642,18 +751,17 @@ describe("scaffoldManaged", () => {
     vi.mocked(confirm).mockResolvedValue(Symbol("cancel") as never);
     vi.mocked(isCancel).mockReturnValue(true);
 
-    await runCLI(undefined, []);
+    await expect(runCLI(undefined, [])).rejects.toBeInstanceOf(CancelledError);
 
     expect(rotateServiceToken).not.toHaveBeenCalled();
-    expect(out()).toContain("Cancelled. No token was issued.");
   });
 
-  it("returns early when no application is selected", async () => {
+  it("stops when the application selection is cancelled", async () => {
     loggedIn();
     vi.mocked(listApplications).mockResolvedValue([] as never);
-    vi.mocked(selectApplication).mockResolvedValue(undefined as never);
+    vi.mocked(selectApplication).mockRejectedValue(new CancelledError());
 
-    await runCLI(undefined, []);
+    await expect(runCLI(undefined, [])).rejects.toBeInstanceOf(CancelledError);
 
     expect(rotateServiceToken).not.toHaveBeenCalled();
     expect(printManagedSuccessOutput).not.toHaveBeenCalled();
@@ -744,20 +852,20 @@ describe("integrateExistingProject", () => {
     expect(out()).toContain("svc-token");
   });
 
-  it("returns early when no application is selected", async () => {
+  it("stops when the application selection is cancelled", async () => {
     vi.mocked(createPortalClient).mockResolvedValue({
       profile: { name: "default", instanceUrl: "https://auth" },
     } as never);
     vi.mocked(listApplications).mockResolvedValue([] as never);
-    vi.mocked(selectApplication).mockResolvedValue(undefined as never);
+    vi.mocked(selectApplication).mockRejectedValue(new CancelledError());
 
-    await runCLI(undefined, []);
+    await expect(runCLI(undefined, [])).rejects.toBeInstanceOf(CancelledError);
 
     expect(rotateServiceToken).not.toHaveBeenCalled();
     expect(writeEnv).not.toHaveBeenCalled();
   });
 
-  it("returns early when token issuance is declined", async () => {
+  it("stops when token issuance is declined", async () => {
     vi.mocked(createPortalClient).mockResolvedValue({
       profile: { name: "default", instanceUrl: "https://auth" },
     } as never);
@@ -766,7 +874,7 @@ describe("integrateExistingProject", () => {
     vi.mocked(selectApplication).mockResolvedValue(existing as never);
     vi.mocked(confirm).mockResolvedValue(false as never);
 
-    await runCLI(undefined, []);
+    await expect(runCLI(undefined, [])).rejects.toBeInstanceOf(CancelledError);
 
     expect(rotateServiceToken).not.toHaveBeenCalled();
     expect(writeEnv).not.toHaveBeenCalled();

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import fs from "fs";
 
-import { confirm, isCancel } from "@clack/prompts";
+import { confirm } from "@clack/prompts";
 import kleur from "kleur";
 
 import {
@@ -25,6 +25,7 @@ import {
   type TemplateSource,
 } from "../core/templates.js";
 import { runOAuthSetupPrompts } from "../prompts/oauthSetup.js";
+import { CancelledError, orCancel } from "../core/cancel.js";
 import type { CollectedOAuthProvider } from "../core/oauthProviders.js";
 import {
   createPortalClient,
@@ -74,6 +75,9 @@ export async function runCLI(
   }
 
   let root = cwd;
+  // Only ever set to a directory mkdir just created, never one that already
+  // existed, so discarding it can never take a developer's own files with it.
+  let created: string | null = null;
 
   if (projectName) {
     root = path.join(cwd, projectName);
@@ -83,9 +87,47 @@ export async function runCLI(
     }
 
     fs.mkdirSync(root);
+    created = root;
     console.log(`Creating project in ${root}`);
   }
 
+  // Ctrl-C inside a prompt comes back as a CancelledError and unwinds through
+  // the catch below, but during a download or a git clone it arrives as a real
+  // signal that would otherwise end the process with the husk still on disk.
+  const onInterrupt = () => {
+    discard(created);
+    process.exit(130);
+  };
+  if (created) process.on("SIGINT", onInterrupt);
+
+  try {
+    await scaffold(root, projectName, aliases, opts);
+  } catch (err) {
+    // Anything short of a completed scaffold leaves nothing behind, so a retry
+    // is not blocked by "Directory already exists" from a half-built attempt.
+    discard(created);
+    throw err;
+  } finally {
+    if (created) process.off("SIGINT", onInterrupt);
+  }
+}
+
+function discard(dir: string | null): void {
+  if (!dir) return;
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // The original failure is what the developer needs to see; a cleanup error
+    // on top of it would only bury the cause.
+  }
+}
+
+async function scaffold(
+  root: string,
+  projectName: string | undefined,
+  aliases: string[],
+  opts: InitOptions,
+) {
   // A portal session makes the managed path the default; --local forces the
   // self-hosted stack. A missing session or an unreachable control plane falls
   // back to local, unless managed was requested explicitly (handled below).
@@ -176,7 +218,6 @@ async function scaffoldManaged(
   // or an authorization failure leaves nothing behind.
   const apps = await listApplications(client);
   const app = await selectApplication(connectable(apps), opts.appId);
-  if (!app) return;
 
   // Copy templates before rotating the service token. Rotation invalidates the
   // app's previous token (see rotateServiceToken), so it runs as late as possible;
@@ -187,7 +228,6 @@ async function scaffoldManaged(
   }
 
   const serviceToken = await issueServiceToken(client, app);
-  if (serviceToken === null) return;
 
   const authServerUrl = normalizeInstanceUrl(app.domain);
 
@@ -360,10 +400,8 @@ async function integrateExistingProject(
 
   const apps = await listApplications(client);
   const app = await selectApplication(connectable(apps), opts.appId);
-  if (!app) return;
 
   const serviceToken = await issueServiceToken(client, app);
-  if (serviceToken === null) return;
 
   const authServerUrl = normalizeInstanceUrl(app.domain);
   const apiDir = path.join(root, "api");
@@ -435,20 +473,21 @@ function printManagedValues(authServerUrl: string, serviceToken: string) {
 }
 
 // Issues the app's service token, confirming first when one already exists so a
-// scaffold does not silently break an app that is already deployed. Returns null
-// only when the developer declines the rotation.
+// scaffold does not silently break an app that is already deployed. Declining
+// cancels the whole command, so nothing is left half-wired.
 async function issueServiceToken(
   client: AuthClient,
   app: PortalApp,
-): Promise<string | null> {
+): Promise<string> {
   if (app.hasServiceToken) {
-    const proceed = await confirm({
-      message: `"${app.name}" already has a service token. Issuing a new one invalidates the existing token. Continue?`,
-      initialValue: false,
-    });
-    if (isCancel(proceed) || !proceed) {
-      console.log("Cancelled. No token was issued.");
-      return null;
+    const proceed = orCancel(
+      await confirm({
+        message: `"${app.name}" already has a service token. Issuing a new one invalidates the existing token. Continue?`,
+        initialValue: false,
+      }),
+    );
+    if (!proceed) {
+      throw new CancelledError("Cancelled. No token was issued.");
     }
   }
   return rotateServiceToken(client, app.id);

--- a/src/core/cancel.ts
+++ b/src/core/cancel.ts
@@ -1,0 +1,35 @@
+import { isCancel } from "@clack/prompts";
+
+// Raised when a developer interrupts a prompt (Ctrl-C) or declines a
+// confirmation. Callers let it propagate: init unwinds anything it created and
+// the top level reports it as a cancellation rather than a failure.
+export class CancelledError extends Error {
+  constructor(message = "Cancelled.") {
+    super(message);
+    this.name = "CancelledError";
+  }
+}
+
+// Matches on the name as well as the prototype. A CLI that is bundled, linked,
+// or loaded through more than one module instance can raise an error that is
+// structurally this class without sharing its identity, and a missed match here
+// would report a plain Ctrl-C as a crash.
+export function isCancelled(err: unknown): boolean {
+  if (err instanceof CancelledError) return true;
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { name?: unknown }).name === "CancelledError"
+  );
+}
+
+// Clack answers an interrupted prompt with a symbol rather than rejecting.
+// Casting that result to its value type (the pattern this replaces) turned the
+// symbol into a TypeError somewhere further down, which surfaced as a crash
+// mid-scaffold instead of a clean exit. Every prompt result goes through here.
+export function orCancel<T>(value: T | symbol): T {
+  if (isCancel(value)) {
+    throw new CancelledError();
+  }
+  return value as T;
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -116,10 +116,27 @@ describe("index dispatcher", () => {
     expect(mod[fnName]).toHaveBeenCalledWith(["sub", "--flag"]);
   });
 
-  it("treats an unknown command as an init template alias", async () => {
+  // An unmatched first arg used to be scaffolded as a project name, so every
+  // typo silently created a directory.
+  it("rejects an unknown command instead of scaffolding it", async () => {
     await dispatch(["frobnicate"]);
+
     const { runCLI } = await import("./commands/init.js");
-    expect(runCLI).toHaveBeenCalledWith("frobnicate");
+    expect(runCLI).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    const errors = errSpy.mock.calls.map((c) => c[0] as string).join("\n");
+    expect(errors).toContain('Unknown command "frobnicate"');
+    expect(errors).toContain("seamless init frobnicate");
+    expect(errors).toContain("apps");
+  });
+
+  it("does not offer init as a fix for a flag-like argument", async () => {
+    await dispatch(["--frobnicate"]);
+
+    const errors = errSpy.mock.calls.map((c) => c[0] as string).join("\n");
+    expect(errors).toContain('Unknown command "--frobnicate"');
+    expect(errors).not.toContain("seamless init --frobnicate");
   });
 
   it("logs the error and exits 1 when a command rejects", async () => {
@@ -133,6 +150,25 @@ describe("index dispatcher", () => {
 
     expect(errSpy).toHaveBeenCalledWith("Error:", "kaboom");
     expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  // Ctrl-C is not a failure: it reports as a cancellation on stdout and uses the
+  // conventional interrupt status rather than the generic error path.
+  it("reports a cancellation and exits 130", async () => {
+    process.argv = ["node", "index.js", "check"];
+    const { runCheck } = await import("./commands/check.js");
+    const { CancelledError } = await import("./core/cancel.js");
+    vi.mocked(runCheck).mockRejectedValueOnce(new CancelledError());
+
+    await import("./index.js");
+    await flush();
+    await flush();
+
+    // Only positive assertions here: both rejection tests import index fresh and
+    // main() settles on its own schedule, so one test's tail can still be in
+    // flight while the next runs and would pollute a "never called" check.
+    expect(logSpy).toHaveBeenCalledWith("Cancelled.");
+    expect(exitSpy).toHaveBeenCalledWith(130);
   });
 
   it("exports VERSION from package.json", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,27 @@ import { runConfig } from "./commands/config.js";
 import { runUsers } from "./commands/users.js";
 import { runOrg } from "./commands/org.js";
 import { runApps } from "./commands/apps.js";
+import { isCancelled } from "./core/cancel.js";
+import kleur from "kleur";
 
 export const VERSION = pkg.version;
+
+const COMMANDS = [
+  "init",
+  "check",
+  "bootstrap-admin",
+  "verify",
+  "profile",
+  "login",
+  "apps",
+  "whoami",
+  "logout",
+  "sessions",
+  "config",
+  "users",
+  "org",
+];
+
 const args = process.argv.slice(2);
 
 const command = args[0];
@@ -117,10 +136,27 @@ async function main() {
     return;
   }
 
-  await runCLI(command);
+  // An unrecognized command used to be treated as a project name and scaffolded,
+  // which made every typo create a directory with no indication the command was
+  // not understood. Scaffolding is `init` and nothing else.
+  console.error(kleur.red(`Unknown command "${command}".`));
+  if (!command.startsWith("-")) {
+    console.error(
+      kleur.dim("To scaffold a project, run: ") +
+        kleur.cyan(`seamless init ${command}`),
+    );
+  }
+  console.error(kleur.dim(`Commands: ${COMMANDS.join(", ")}`));
+  console.error(kleur.dim("Run seamless --help for details."));
+  process.exit(1);
 }
 
 main().catch((err) => {
+  if (isCancelled(err)) {
+    console.log(err.message);
+    // 130 is the conventional exit status for a command ended by Ctrl-C.
+    process.exit(130);
+  }
   console.error("Error:", err.message);
   process.exit(1);
 });

--- a/src/prompts/appSelect.test.ts
+++ b/src/prompts/appSelect.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { select, isCancel, cancel } from "@clack/prompts";
+import { CancelledError } from "../core/cancel.js";
 import type { PortalApp } from "../core/portal.js";
 import { NoApplicationsError, selectApplication } from "./appSelect.js";
 
@@ -69,27 +70,28 @@ describe("selectApplication", () => {
     expect(cancel).not.toHaveBeenCalled();
   });
 
-  it("returns null and cancels when the interactive prompt is cancelled", async () => {
+  it("cancels when the interactive prompt is cancelled", async () => {
     const a = app({ id: "app-1" });
     const b = app({ id: "app-2" });
     const cancelSymbol = Symbol("cancel");
     vi.mocked(select).mockResolvedValue(cancelSymbol as never);
     vi.mocked(isCancel).mockReturnValue(true);
 
-    const result = await selectApplication([a, b]);
-
-    expect(cancel).toHaveBeenCalledWith("Cancelled.");
-    expect(result).toBeNull();
+    // Throwing rather than returning null is what lets init unwind the project
+    // directory it created.
+    await expect(selectApplication([a, b])).rejects.toBeInstanceOf(
+      CancelledError,
+    );
   });
 
-  it("returns null when the selected value no longer matches any application", async () => {
+  it("errors when the selected value no longer matches any application", async () => {
     const a = app({ id: "app-1" });
     const b = app({ id: "app-2" });
     vi.mocked(select).mockResolvedValue("app-3" as never);
     vi.mocked(isCancel).mockReturnValue(false);
 
-    const result = await selectApplication([a, b]);
-
-    expect(result).toBeNull();
+    await expect(selectApplication([a, b])).rejects.toThrow(
+      /no longer available/,
+    );
   });
 });

--- a/src/prompts/appSelect.ts
+++ b/src/prompts/appSelect.ts
@@ -1,5 +1,6 @@
-import { select, isCancel, cancel } from "@clack/prompts";
+import { select } from "@clack/prompts";
 
+import { orCancel } from "../core/cancel.js";
 import { resolveAppInstanceUrl, type PortalApp } from "../core/portal.js";
 
 export class NoApplicationsError extends Error {
@@ -13,13 +14,13 @@ export class NoApplicationsError extends Error {
 
 // Resolves which managed application the scaffold connects to. `--app` matches an
 // id or infra id; a single application is auto-selected; otherwise the developer
-// picks. Returns null only when an interactive selection is cancelled.
+// picks. Cancelling throws CancelledError, so init can unwind what it created.
 // Generic over the app type so a caller that has already narrowed to applications
 // with a resolvable instance URL keeps that guarantee on the selected one.
 export async function selectApplication<T extends PortalApp>(
   apps: T[],
   preselectId?: string,
-): Promise<T | null> {
+): Promise<T> {
   if (apps.length === 0) {
     throw new NoApplicationsError();
   }
@@ -44,19 +45,20 @@ export async function selectApplication<T extends PortalApp>(
     return apps[0];
   }
 
-  const choice = await select({
-    message: "Which managed application should this project connect to?",
-    options: apps.map((a) => ({
-      value: a.id,
-      label: a.name,
-      hint: resolveAppInstanceUrl(a),
-    })),
-  });
+  const choice = orCancel(
+    await select({
+      message: "Which managed application should this project connect to?",
+      options: apps.map((a) => ({
+        value: a.id,
+        label: a.name,
+        hint: resolveAppInstanceUrl(a),
+      })),
+    }),
+  );
 
-  if (isCancel(choice)) {
-    cancel("Cancelled.");
-    return null;
+  const chosen = apps.find((a) => a.id === choice);
+  if (!chosen) {
+    throw new Error(`Selected application "${String(choice)}" is no longer available.`);
   }
-
-  return apps.find((a) => a.id === choice) ?? null;
+  return chosen;
 }

--- a/src/prompts/oauthSetup.test.ts
+++ b/src/prompts/oauthSetup.test.ts
@@ -4,11 +4,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { OAUTH_PROVIDER_CATALOG } from "../core/oauthProviders.js";
 import { runOAuthSetupPrompts } from "./oauthSetup.js";
 
-vi.mock("@clack/prompts", () => ({
-  multiselect: vi.fn(),
-  text: vi.fn(),
-  password: vi.fn(),
-}));
+vi.mock("@clack/prompts", () => {
+  const CANCEL = Symbol("cancel");
+  return {
+    CANCEL,
+    multiselect: vi.fn(),
+    text: vi.fn(),
+    password: vi.fn(),
+    isCancel: (value: unknown) => value === CANCEL,
+  };
+});
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/src/prompts/oauthSetup.ts
+++ b/src/prompts/oauthSetup.ts
@@ -1,5 +1,6 @@
 import { multiselect, password, text } from "@clack/prompts";
 
+import { orCancel } from "../core/cancel.js";
 import {
   OAUTH_PROVIDER_CATALOG,
   type CollectedOAuthProvider,
@@ -10,11 +11,13 @@ import {
 // server has OAuth working right after `docker compose up`. Blank credentials are
 // allowed (the provider is scaffolded disabled for the user to fill in later).
 export async function runOAuthSetupPrompts(): Promise<CollectedOAuthProvider[]> {
-  const chosen = (await multiselect({
-    message: "Which OAuth providers do you want to enable? (space to select)",
-    options: OAUTH_PROVIDER_CATALOG.map((p) => ({ value: p.id, label: p.label })),
-    required: false,
-  })) as string[];
+  const chosen = orCancel(
+    await multiselect({
+      message: "Which OAuth providers do you want to enable? (space to select)",
+      options: OAUTH_PROVIDER_CATALOG.map((p) => ({ value: p.id, label: p.label })),
+      required: false,
+    }),
+  ) as string[];
 
   if (!Array.isArray(chosen) || chosen.length === 0) {
     return [];
@@ -26,14 +29,18 @@ export async function runOAuthSetupPrompts(): Promise<CollectedOAuthProvider[]> 
     const catalog = OAUTH_PROVIDER_CATALOG.find((p) => p.id === id);
     if (!catalog) continue;
 
-    const clientId = (await text({
-      message: `${catalog.label} client ID`,
-      placeholder: "leave blank to configure later",
-    })) as string;
+    const clientId = orCancel(
+      await text({
+        message: `${catalog.label} client ID`,
+        placeholder: "leave blank to configure later",
+      }),
+    ) as string;
 
-    const clientSecret = (await password({
-      message: `${catalog.label} client secret`,
-    })) as string;
+    const clientSecret = orCancel(
+      await password({
+        message: `${catalog.label} client secret`,
+      }),
+    ) as string;
 
     collected.push({
       catalog,

--- a/src/prompts/projectSetup.test.ts
+++ b/src/prompts/projectSetup.test.ts
@@ -7,10 +7,15 @@ import {
   runProjectSetupPrompts,
 } from "./projectSetup.js";
 
-vi.mock("@clack/prompts", () => ({
-  select: vi.fn(),
-  confirm: vi.fn(),
-}));
+vi.mock("@clack/prompts", () => {
+  const CANCEL = Symbol("cancel");
+  return {
+    CANCEL,
+    select: vi.fn(),
+    confirm: vi.fn(),
+    isCancel: (value: unknown) => value === CANCEL,
+  };
+});
 
 interface SelectArgs {
   message: string;

--- a/src/prompts/projectSetup.ts
+++ b/src/prompts/projectSetup.ts
@@ -1,5 +1,7 @@
 import { confirm, select } from "@clack/prompts";
 
+import { orCancel } from "../core/cancel.js";
+
 import type { RegistryEntry, TemplateKind } from "../core/templates.js";
 
 type AuthMode = "local" | "docker";
@@ -51,20 +53,24 @@ export async function runManagedTemplatePrompts(
   if (webTemplateId) {
     console.log(`Web example: ${labelFor(templates, webTemplateId)}`);
   } else {
-    webTemplateId = (await select({
-      message: "Web example",
-      options: toOptions(templates, "web"),
-    })) as string;
+    webTemplateId = orCancel(
+      await select({
+        message: "Web example",
+        options: toOptions(templates, "web"),
+      }),
+    ) as string;
   }
 
   let apiTemplateId = preselect.apiTemplateId;
   if (apiTemplateId) {
     console.log(`Backend: ${labelFor(templates, apiTemplateId)}`);
   } else {
-    apiTemplateId = (await select({
-      message: "Backend framework",
-      options: toOptions(templates, "api"),
-    })) as string;
+    apiTemplateId = orCancel(
+      await select({
+        message: "Backend framework",
+        options: toOptions(templates, "api"),
+      }),
+    ) as string;
   }
 
   return { webTemplateId, apiTemplateId };
@@ -78,65 +84,75 @@ export async function runProjectSetupPrompts(
   if (webTemplateId) {
     console.log(`Web example: ${labelFor(templates, webTemplateId)}`);
   } else {
-    webTemplateId = (await select({
-      message: "Web example",
-      options: toOptions(templates, "web"),
-    })) as string;
+    webTemplateId = orCancel(
+      await select({
+        message: "Web example",
+        options: toOptions(templates, "web"),
+      }),
+    ) as string;
   }
 
   let apiTemplateId = preselect.apiTemplateId;
   if (apiTemplateId) {
     console.log(`Backend: ${labelFor(templates, apiTemplateId)}`);
   } else {
-    apiTemplateId = (await select({
-      message: "Backend framework",
-      options: toOptions(templates, "api"),
-    })) as string;
+    apiTemplateId = orCancel(
+      await select({
+        message: "Backend framework",
+        options: toOptions(templates, "api"),
+      }),
+    ) as string;
   }
 
-  const authMode = (await select({
-    message: "How would you like to run SeamlessAuth?",
-    options: [
-      {
-        value: "docker",
-        label: "Docker container (recommended)",
-      },
-      {
-        value: "local",
-        label: "Local dev server (advanced)",
-      },
-    ],
-  })) as AuthMode;
+  const authMode = orCancel(
+    await select({
+      message: "How would you like to run SeamlessAuth?",
+      options: [
+        {
+          value: "docker",
+          label: "Docker container (recommended)",
+        },
+        {
+          value: "local",
+          label: "Local dev server (advanced)",
+        },
+      ],
+    }),
+  ) as AuthMode;
 
-  const adminMode = (await select({
-    message: "How would you like to host the admin console?",
-    options: [
-      {
-        value: "api",
-        label: "Served by your API at /console (recommended)",
-      },
-      {
-        value: "image",
-        label: "Separate container — official Docker image",
-      },
-      {
-        value: "source",
-        label: "Separate container — clone repo for modification",
-      },
-      {
-        value: "none",
-        label: "Don't include the admin console",
-      },
-    ],
-    initialValue: "api",
-  })) as AdminMode;
+  const adminMode = orCancel(
+    await select({
+      message: "How would you like to host the admin console?",
+      options: [
+        {
+          value: "api",
+          label: "Served by your API at /console (recommended)",
+        },
+        {
+          value: "image",
+          label: "Separate container — official Docker image",
+        },
+        {
+          value: "source",
+          label: "Separate container — clone repo for modification",
+        },
+        {
+          value: "none",
+          label: "Don't include the admin console",
+        },
+      ],
+      initialValue: "api",
+    }),
+  ) as AdminMode;
 
   if (authMode === "local") {
-    const confirmDocker = await confirm({
-      message:
-        "Auth server still requires Docker for full stack. Enable Docker?",
-      initialValue: true,
-    });
+    const confirmDocker = orCancel(
+      await confirm({
+        message:
+          "Auth server still requires Docker for full stack. Enable Docker?",
+        initialValue: true,
+      }),
+    );
 
     if (!confirmDocker) {
       console.log(


### PR DESCRIPTION
Closes #83, #84, #130.

Three related failures around starting and abandoning a scaffold.

## Scaffolding requires `init`

Any unmatched first argument fell through to `runCLI`, so it was treated as a project name. That
made every typo destructive: `seamless verfy` created a directory called `verfy` and dropped into
the interactive scaffold with no sign the command was not recognized. There was no way to get an
"unknown command" out of this CLI, because no command was unknown.

Unknown commands now report themselves, list the available commands, and exit 1. The message names
`seamless init <name>` for anyone who was using the shortcut, and omits that line when the argument
is flag-like.

This is a breaking change and it contradicts the recommendation in #96, which proposed keeping the
shortcut and rejecting only flag-like or known-typo arguments. Distinguishing "typo" from "project
name" is a guess the CLI should not have to make. The other half of #96 (rendering non-Error throws
safely) stays open.

## Ctrl-C is handled

Clack answers an interrupted prompt with a symbol rather than rejecting, and several prompts cast
that result straight to a string. Ctrl-C therefore surfaced as a `TypeError` mid-scaffold, or as
`Selected template Symbol(...) is not in the registry`, and `bootstrap-admin` treated a cancelled
confirm as a yes (the symbol is truthy).

`orCancel` in the new `src/core/cancel.ts` funnels every prompt result through one check and raises
`CancelledError`. Applied across init's template prompts, the OAuth setup, the managed application
picker, and all three `bootstrap-admin` prompts. The top level reports it on stdout and exits 130,
the conventional interrupt status, rather than through the generic error path.

Declining the service-token rotation prompt and cancelling the application picker now cancel the
command instead of returning quietly part-way through, so those paths clean up like any other
cancellation.

## No orphaned directories

`runCLI` did `mkdirSync` and then ran network fetches, prompts, a git clone, and file writes with no
cleanup. Any failure left a partial directory, and the retry then failed with "Directory already
exists".

The post-mkdir work is now wrapped, and anything short of a completed scaffold removes the
directory. That includes a real `SIGINT` during a download or a git clone, which arrives as a signal
rather than a cancelled prompt and would otherwise end the process with the husk still on disk, so
there is a handler installed for the duration and removed after.

Only a directory `mkdirSync` just created is ever removed. `init` with no name targets the
developer's working directory and never registers one, and an existing directory is rejected before
any of this runs. Both are covered by tests.

## One judgment call

`isCancelled` matches on the error name as well as the prototype. A cross-instance identity miss
would report a plain Ctrl-C as a crash, and this ships as a linked and bundled CLI where a duplicate
module instance is realistic. It also happens to be what the index test needs, since vitest's module
handling gave the two paths different class identities.

I also dropped one assertion in that test (`expect(errSpy).not.toHaveBeenCalled()`). Both rejection
tests import index fresh and `main()` settles on its own schedule, so one test's tail can still be in
flight while the next runs, and exit was recorded as `[130, 1]`. The positive assertions (the
cancellation is logged, 130 is the status) still cover the behavior; the dropped one only described
what an unrelated test did not do.

## Testing

`npm run build` and `npm test` pass (677 passed, 4 skipped). `npm run coverage` holds: 99.36% lines,
96.35% branches, 99.67% functions, with `index.ts`, `cancel.ts`, `appSelect.ts`, and
`projectSetup.ts` at 100%.

New tests cover the unknown-command path (including that it does not suggest `init` for a flag),
cancellation exiting 130, directory removal on failure and on cancellation, removal after a
simulated SIGINT, the working directory never being removed, an existing directory being left alone,
a cleanup failure not burying the original error, and the interrupt handler being detached.
