### PR TITLE
feat: make init offer the managed path instead of assuming it

### DIFF
--- a/.changeset/init-mode-prompts.md
+++ b/.changeset/init-mode-prompts.md
@@ -13,9 +13,10 @@ That message now distinguishes "no applications yet" from "still provisioning", 
 `NoApplicationsError` got wrong for anyone mid-provision.
 
 A directory that already has files is no longer forced down the integrate path. `init` asks whether
-to connect it to a managed application or scaffold in place, and warns that starter files overwrite
-anything with the same name. Scaffolding into a non-empty directory was previously impossible, so a
-stray `README` or `.git` was enough to block a local project.
+to connect it to a managed application or scaffold in place. Scaffolding into a non-empty directory
+was previously impossible, so a stray `README` or `.git` was enough to block a local project, and
+every route that now reaches it confirms first: starter files overwrite anything with the same name,
+and the confirmation defaults to no.
 
 An unreachable control plane asks before scaffolding a local stack rather than degrading silently.
 

--- a/.changeset/init-mode-prompts.md
+++ b/.changeset/init-mode-prompts.md
@@ -1,0 +1,23 @@
+---
+"seamless-cli": minor
+---
+
+`init` now offers the managed path instead of assuming it. A portal session used to make managed the
+default silently, with `--local` as the only escape and no way to learn you needed it until after the
+template prompts. When your account has a provisioned application, `init` asks whether to connect it
+or scaffold a local stack, with managed leading.
+
+Whether managed is even possible is resolved before the first prompt. An account with nothing to
+connect no longer answers two prompts and then fails: it says why and continues to a local scaffold.
+That message now distinguishes "no applications yet" from "still provisioning", which the old
+`NoApplicationsError` got wrong for anyone mid-provision.
+
+A directory that already has files is no longer forced down the integrate path. `init` asks whether
+to connect it to a managed application or scaffold in place, and warns that starter files overwrite
+anything with the same name. Scaffolding into a non-empty directory was previously impossible, so a
+stray `README` or `.git` was enough to block a local project.
+
+An unreachable control plane asks before scaffolding a local stack rather than degrading silently.
+
+`--local` and `--app <id>` skip the new prompts, and `--app` without a session still fails rather
+than falling back.

--- a/README.md
+++ b/README.md
@@ -35,14 +35,19 @@ You’ll be guided through a short setup process where you can choose:
 
 ## Connecting to a managed instance
 
-If you are signed in to the Seamless portal (`seamless login`), `init` connects the new project to
-your managed instance instead of scaffolding a local auth server. This is the default whenever a
-portal session exists.
+If you are signed in to the Seamless portal (`seamless login`) and your account has at least one
+provisioned application, `init` offers to connect the new project to it instead of scaffolding a
+local auth server. Managed leads the prompt, since being signed in signals intent, but it is a
+question rather than an assumption.
 
 ```bash
 seamless login          # once, no profile needed
-seamless init my-app    # scaffolds web + api wired to the managed instance
+seamless init my-app    # asks: connect a managed application, or scaffold local
 ```
+
+With no session, nothing provisioned yet, or `--local`, you get the local stack below. An account
+whose applications are still provisioning is told so and continues to a local scaffold rather than
+failing.
 
 What happens:
 
@@ -82,10 +87,15 @@ invalidates the old one.
 
 Escape hatches:
 
-- `seamless init --local` forces the self-hosted flow below, even when signed in.
+- `seamless init --local` forces the self-hosted flow below without contacting the control plane.
+- `seamless init --app <id>` is explicit managed intent: it skips both questions and fails rather
+  than silently scaffolding local if you are not signed in.
 - With no portal session, `init` uses the self-hosted flow automatically. A profile session is not
   consulted: signing in to an auth instance you administer says nothing about whether you have a
   managed account.
+- In a directory that already has files, `init` asks whether to connect it to a managed application
+  or scaffold in place. Starter files overwrite anything with the same name, so scaffolding there is
+  never assumed.
 - `SEAMLESS_PORTAL_API_URL` overrides the control-plane host (defaults to the managed service), and
   `SEAMLESS_PORTAL_AUTH_URL` overrides the portal auth instance the login targets.
 

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -22,6 +22,11 @@ import {
 import { createPortalClient, ReauthRequiredError } from "../core/authClient.js";
 import { listApplications, rotateServiceToken } from "../core/portal.js";
 import { selectApplication } from "../prompts/appSelect.js";
+import {
+  chooseExistingDirectoryAction,
+  chooseScaffoldTarget,
+  confirmLocalFallback,
+} from "../prompts/initMode.js";
 import { parseEnv, writeEnv } from "../core/env.js";
 
 import { CancelledError } from "../core/cancel.js";
@@ -55,6 +60,11 @@ vi.mock("../prompts/oauthSetup.js", () => ({
 }));
 vi.mock("../prompts/appSelect.js", () => ({
   selectApplication: vi.fn(),
+}));
+vi.mock("../prompts/initMode.js", () => ({
+  chooseExistingDirectoryAction: vi.fn(),
+  chooseScaffoldTarget: vi.fn(),
+  confirmLocalFallback: vi.fn(),
 }));
 vi.mock("../generators/auth/auth.js", () => ({
   generateAuthServer: vi.fn(),
@@ -180,6 +190,10 @@ beforeEach(() => {
   // Empty directory by default (fresh scaffold).
   vi.mocked(fs.readdirSync).mockReturnValue([] as never);
   vi.mocked(fs.existsSync).mockReturnValue(false);
+  // Default answers for the mode prompts; individual tests override.
+  vi.mocked(chooseExistingDirectoryAction).mockResolvedValue("integrate");
+  vi.mocked(chooseScaffoldTarget).mockResolvedValue("managed");
+  vi.mocked(confirmLocalFallback).mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -366,7 +380,9 @@ describe("resolveManagedClient", () => {
 
     expect(runProjectSetupPrompts).toHaveBeenCalled();
     expect(runManagedTemplatePrompts).not.toHaveBeenCalled();
-    expect(out()).toContain("Could not reach the control plane");
+    // Degrading from managed to a full local Docker stack is confirmed rather
+    // than announced after the fact.
+    expect(confirmLocalFallback).toHaveBeenCalled();
   });
 
   it("errors when --app is given but there is no session (no silent local fallback)", async () => {
@@ -758,7 +774,7 @@ describe("scaffoldManaged", () => {
 
   it("stops when the application selection is cancelled", async () => {
     loggedIn();
-    vi.mocked(listApplications).mockResolvedValue([] as never);
+    vi.mocked(listApplications).mockResolvedValue([app(), app({ id: "app-2" })] as never);
     vi.mocked(selectApplication).mockRejectedValue(new CancelledError());
 
     await expect(runCLI(undefined, [])).rejects.toBeInstanceOf(CancelledError);
@@ -768,21 +784,163 @@ describe("scaffoldManaged", () => {
   });
 });
 
+describe("init mode selection", () => {
+  function loggedInWith(apps: unknown[]) {
+    vi.mocked(createPortalClient).mockResolvedValue({
+      profile: { name: "default", instanceUrl: "https://auth" },
+    } as never);
+    vi.mocked(listApplications).mockResolvedValue(apps as never);
+    vi.mocked(openTemplateSource).mockResolvedValue(makeSource() as never);
+    vi.mocked(runManagedTemplatePrompts).mockResolvedValue({
+      webTemplateId: "web-basic",
+      apiTemplateId: "api-express",
+    } as never);
+    vi.mocked(runProjectSetupPrompts).mockResolvedValue({
+      webTemplateId: "web-basic",
+      apiTemplateId: "api-express",
+      authMode: "docker",
+      adminMode: "image",
+      useDocker: true,
+    } as never);
+    vi.mocked(generateDockerCompose).mockResolvedValue({} as never);
+  }
+
+  it("asks whether to connect managed or scaffold local", async () => {
+    loggedInWith([app(), app({ id: "app-2" })]);
+    vi.mocked(selectApplication).mockResolvedValue(app() as never);
+    vi.mocked(rotateServiceToken).mockResolvedValue("svc-token");
+
+    await runCLI(undefined, []);
+
+    expect(chooseScaffoldTarget).toHaveBeenCalledWith(2);
+    expect(printManagedSuccessOutput).toHaveBeenCalled();
+  });
+
+  it("scaffolds local when that is the answer, despite a session", async () => {
+    loggedInWith([app()]);
+    vi.mocked(chooseScaffoldTarget).mockResolvedValue("local");
+
+    await runCLI(undefined, []);
+
+    expect(runProjectSetupPrompts).toHaveBeenCalled();
+    expect(rotateServiceToken).not.toHaveBeenCalled();
+  });
+
+  // The old flow asked for templates first and only then discovered there was
+  // nothing to connect, ending in a hard error.
+  it("falls through to local when the account has no applications", async () => {
+    loggedInWith([]);
+
+    await runCLI(undefined, []);
+
+    expect(chooseScaffoldTarget).not.toHaveBeenCalled();
+    expect(runProjectSetupPrompts).toHaveBeenCalled();
+    expect(out()).toContain("no managed applications yet");
+  });
+
+  it("says provisioning when an application exists but has no URL yet", async () => {
+    loggedInWith([app({ domain: undefined })]);
+
+    await runCLI(undefined, []);
+
+    expect(out()).toContain("still provisioning");
+    expect(out()).not.toContain("no managed applications yet");
+    expect(runProjectSetupPrompts).toHaveBeenCalled();
+  });
+
+  it("does not ask when --app names the intent", async () => {
+    loggedInWith([app()]);
+    vi.mocked(selectApplication).mockResolvedValue(app() as never);
+    vi.mocked(rotateServiceToken).mockResolvedValue("svc-token");
+
+    await runCLI(undefined, [], { appId: "app-1" });
+
+    expect(chooseScaffoldTarget).not.toHaveBeenCalled();
+    expect(printManagedSuccessOutput).toHaveBeenCalled();
+  });
+
+  it("does not reach the control plane at all with --local", async () => {
+    vi.mocked(openTemplateSource).mockResolvedValue(makeSource() as never);
+    vi.mocked(runProjectSetupPrompts).mockResolvedValue({
+      webTemplateId: "web-basic",
+      apiTemplateId: "api-express",
+      authMode: "docker",
+      adminMode: "image",
+      useDocker: true,
+    } as never);
+    vi.mocked(generateDockerCompose).mockResolvedValue({} as never);
+
+    await runCLI(undefined, [], { local: true });
+
+    expect(createPortalClient).not.toHaveBeenCalled();
+    expect(listApplications).not.toHaveBeenCalled();
+    expect(chooseScaffoldTarget).not.toHaveBeenCalled();
+  });
+
+  it("offers integrate only when there is something to connect", async () => {
+    vi.mocked(fs.readdirSync).mockReturnValue(["package.json"] as never);
+    loggedInWith([app()]);
+    vi.mocked(selectApplication).mockResolvedValue(app() as never);
+    vi.mocked(rotateServiceToken).mockResolvedValue("svc-token");
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    await runCLI(undefined, []);
+
+    expect(chooseExistingDirectoryAction).toHaveBeenCalledWith(true);
+  });
+
+  it("scaffolds into a non-empty directory when that is the answer", async () => {
+    vi.mocked(fs.readdirSync).mockReturnValue(["README.md"] as never);
+    loggedInWith([app()]);
+    vi.mocked(chooseExistingDirectoryAction).mockResolvedValue("scaffold");
+    vi.mocked(chooseScaffoldTarget).mockResolvedValue("local");
+
+    await runCLI(undefined, []);
+
+    expect(runProjectSetupPrompts).toHaveBeenCalled();
+    expect(rotateServiceToken).not.toHaveBeenCalled();
+  });
+
+  it("skips the directory question when --app names the intent", async () => {
+    vi.mocked(fs.readdirSync).mockReturnValue(["package.json"] as never);
+    loggedInWith([app()]);
+    vi.mocked(selectApplication).mockResolvedValue(app() as never);
+    vi.mocked(rotateServiceToken).mockResolvedValue("svc-token");
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    await runCLI(undefined, [], { appId: "app-1" });
+
+    expect(chooseExistingDirectoryAction).not.toHaveBeenCalled();
+  });
+});
+
 describe("integrateExistingProject", () => {
   beforeEach(() => {
     // Non-empty directory triggers the existing-project path.
     vi.mocked(fs.readdirSync).mockReturnValue(["package.json"] as never);
   });
 
-  it("prints login guidance when there is no session", async () => {
+  // Without a session there is nothing to integrate, so the only offer is to
+  // scaffold here. This used to be a dead end that printed guidance and quit.
+  it("offers to scaffold in place when there is no session", async () => {
     vi.mocked(createPortalClient).mockRejectedValue(
       new ReauthRequiredError("no session"),
     );
+    vi.mocked(chooseExistingDirectoryAction).mockResolvedValue("scaffold");
+    vi.mocked(openTemplateSource).mockResolvedValue(makeSource() as never);
+    vi.mocked(runProjectSetupPrompts).mockResolvedValue({
+      webTemplateId: "web-basic",
+      apiTemplateId: "api-express",
+      authMode: "docker",
+      adminMode: "image",
+      useDocker: true,
+    } as never);
+    vi.mocked(generateDockerCompose).mockResolvedValue({} as never);
 
     await runCLI(undefined, []);
 
-    expect(out()).toContain("Existing project detected.");
-    expect(out()).toContain("seamless login");
+    expect(chooseExistingDirectoryAction).toHaveBeenCalledWith(false);
+    expect(runProjectSetupPrompts).toHaveBeenCalled();
   });
 
   it("updates api/.env when an api directory exists", async () => {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -25,6 +25,11 @@ import {
   type TemplateSource,
 } from "../core/templates.js";
 import { runOAuthSetupPrompts } from "../prompts/oauthSetup.js";
+import {
+  chooseExistingDirectoryAction,
+  chooseScaffoldTarget,
+  confirmLocalFallback,
+} from "../prompts/initMode.js";
 import { CancelledError, orCancel } from "../core/cancel.js";
 import type { CollectedOAuthProvider } from "../core/oauthProviders.js";
 import {
@@ -128,9 +133,8 @@ async function scaffold(
   aliases: string[],
   opts: InitOptions,
 ) {
-  // A portal session makes the managed path the default; --local forces the
-  // self-hosted stack. A missing session or an unreachable control plane falls
-  // back to local, unless managed was requested explicitly (handled below).
+  // --local forces the self-hosted stack without asking the control plane
+  // anything.
   let client: AuthClient | null = null;
   let fallbackReason: "no-session" | "unreachable" | null = null;
   if (!opts.local) {
@@ -149,27 +153,53 @@ async function scaffold(
     );
   }
 
+  // Whether managed is even possible is settled before the first prompt, so a
+  // session with nothing to connect never costs a round of questions first.
+  const allApps = client ? await listApplications(client) : [];
+  const apps = connectable(allApps);
+  const canConnect = client !== null && apps.length > 0;
+
   const isEmpty = fs.readdirSync(root).length === 0;
-
   if (!isEmpty) {
-    await integrateExistingProject(root, client, opts);
-    return;
+    // --app is explicit managed intent, so it skips the question and integrates.
+    const action = opts.appId
+      ? "integrate"
+      : await chooseExistingDirectoryAction(canConnect);
+    if (action === "integrate") {
+      await integrateExistingProject(root, client!, apps, opts);
+      return;
+    }
   }
 
-  if (client) {
-    await scaffoldManaged(root, projectName, aliases, client, opts);
-  } else {
-    if (fallbackReason) {
-      console.log(
-        kleur.yellow(
-          fallbackReason === "unreachable"
-            ? "Could not reach the control plane; scaffolding a local project instead. Use --local to skip this check."
-            : "Not logged in; scaffolding a local project. Run `seamless login` first to connect a managed instance.",
-        ),
-      );
+  if (canConnect) {
+    const target = opts.appId
+      ? "managed"
+      : await chooseScaffoldTarget(apps.length);
+    if (target === "managed") {
+      await scaffoldManaged(root, projectName, aliases, client!, apps, opts);
+      return;
     }
-    await scaffoldLocal(root, projectName, aliases);
+  } else if (client) {
+    console.log(kleur.yellow(noConnectableMessage(allApps.length > 0)));
+  } else if (fallbackReason === "unreachable") {
+    await confirmLocalFallback();
+  } else if (fallbackReason === "no-session") {
+    console.log(
+      kleur.yellow(
+        "Not logged in; scaffolding a local project. Run `seamless login` first to connect a managed instance.",
+      ),
+    );
   }
+
+  await scaffoldLocal(root, projectName, aliases);
+}
+
+// The old message told an account whose only application was still provisioning
+// that it had none and should create one.
+function noConnectableMessage(hasProvisioning: boolean): string {
+  return hasProvisioning
+    ? "Your managed applications are still provisioning, so there is nothing to connect to yet. Scaffolding a local project instead."
+    : "Your account has no managed applications yet (create one at https://dashboard.seamlessauth.com). Scaffolding a local project instead.";
 }
 
 type ManagedResolution =
@@ -198,6 +228,7 @@ async function scaffoldManaged(
   projectName: string | undefined,
   aliases: string[],
   client: AuthClient,
+  apps: ConnectableApp[],
   opts: InitOptions,
 ) {
   const source = await openTemplateSource();
@@ -216,8 +247,7 @@ async function scaffoldManaged(
 
   // Resolve the target application before writing files, so a cancelled selection
   // or an authorization failure leaves nothing behind.
-  const apps = await listApplications(client);
-  const app = await selectApplication(connectable(apps), opts.appId);
+  const app = await selectApplication(apps, opts.appId);
 
   // Copy templates before rotating the service token. Rotation invalidates the
   // app's previous token (see rotateServiceToken), so it runs as late as possible;
@@ -380,26 +410,11 @@ async function scaffoldLocal(
 // to paste in by hand.
 async function integrateExistingProject(
   root: string,
-  client: AuthClient | null,
+  client: AuthClient,
+  apps: ConnectableApp[],
   opts: InitOptions,
 ) {
-  if (!client) {
-    console.log("Existing project detected.");
-    console.log(
-      "Log in first to connect it to a managed instance: " +
-        kleur.cyan("seamless login") +
-        ".",
-    );
-    console.log(
-      kleur.dim(
-        "Run init in an empty directory to scaffold a new local project.",
-      ),
-    );
-    return;
-  }
-
-  const apps = await listApplications(client);
-  const app = await selectApplication(connectable(apps), opts.appId);
+  const app = await selectApplication(apps, opts.appId);
 
   const serviceToken = await issueServiceToken(client, app);
 

--- a/src/prompts/initMode.test.ts
+++ b/src/prompts/initMode.test.ts
@@ -47,9 +47,35 @@ describe("chooseExistingDirectoryAction", () => {
     expect(confirm).not.toHaveBeenCalled();
   });
 
-  it("returns the scaffold choice", async () => {
+  // Picking "scaffold here" off a list is not consent to write over existing
+  // files; the hint on the option is easy to skim past.
+  it("confirms the overwrite after the scaffold choice is picked", async () => {
     vi.mocked(select).mockResolvedValue("scaffold" as never);
+    vi.mocked(confirm).mockResolvedValue(true as never);
+
     await expect(chooseExistingDirectoryAction(true)).resolves.toBe("scaffold");
+
+    expect(confirm).toHaveBeenCalledTimes(1);
+    const args = lastCall(vi.mocked(confirm));
+    expect(args.message).toMatch(/overwrite/);
+    expect(args.initialValue).toBe(false);
+  });
+
+  it("cancels when the overwrite confirmation after the list is declined", async () => {
+    vi.mocked(select).mockResolvedValue("scaffold" as never);
+    vi.mocked(confirm).mockResolvedValue(false as never);
+
+    await expect(chooseExistingDirectoryAction(true)).rejects.toBeInstanceOf(
+      CancelledError,
+    );
+  });
+
+  it("does not confirm anything when integrating", async () => {
+    vi.mocked(select).mockResolvedValue("integrate" as never);
+
+    await expect(chooseExistingDirectoryAction(true)).resolves.toBe("integrate");
+
+    expect(confirm).not.toHaveBeenCalled();
   });
 
   it("asks for confirmation instead when integrating is not possible", async () => {

--- a/src/prompts/initMode.test.ts
+++ b/src/prompts/initMode.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@clack/prompts", () => {
+  const CANCEL = Symbol("cancel");
+  return {
+    CANCEL,
+    select: vi.fn(),
+    confirm: vi.fn(),
+    isCancel: (value: unknown) => value === CANCEL,
+  };
+});
+
+import { CANCEL, confirm, select } from "@clack/prompts";
+import { CancelledError } from "../core/cancel.js";
+import {
+  chooseExistingDirectoryAction,
+  chooseScaffoldTarget,
+  confirmLocalFallback,
+} from "./initMode.js";
+
+interface PromptArgs {
+  message: string;
+  options?: Array<{ value: string; label: string; hint?: string }>;
+  initialValue?: unknown;
+}
+
+function lastCall(mock: { mock: { calls: unknown[][] } }): PromptArgs {
+  return mock.mock.calls[mock.mock.calls.length - 1][0] as PromptArgs;
+}
+
+beforeEach(() => {
+  vi.mocked(select).mockReset();
+  vi.mocked(confirm).mockReset();
+});
+
+describe("chooseExistingDirectoryAction", () => {
+  it("offers integrate and scaffold when there is something to connect", async () => {
+    vi.mocked(select).mockResolvedValue("integrate" as never);
+
+    await expect(chooseExistingDirectoryAction(true)).resolves.toBe("integrate");
+
+    const args = lastCall(vi.mocked(select));
+    expect(args.options?.map((o) => o.value)).toEqual(["integrate", "scaffold"]);
+    // Scaffolding copies starter files over whatever is already there, so the
+    // consequence has to be on screen before the choice is made.
+    expect(args.options?.[1].hint).toMatch(/overwrite/);
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it("returns the scaffold choice", async () => {
+    vi.mocked(select).mockResolvedValue("scaffold" as never);
+    await expect(chooseExistingDirectoryAction(true)).resolves.toBe("scaffold");
+  });
+
+  it("asks for confirmation instead when integrating is not possible", async () => {
+    vi.mocked(confirm).mockResolvedValue(true as never);
+
+    await expect(chooseExistingDirectoryAction(false)).resolves.toBe("scaffold");
+
+    expect(select).not.toHaveBeenCalled();
+    const args = lastCall(vi.mocked(confirm));
+    expect(args.message).toMatch(/not empty/);
+    expect(args.message).toMatch(/overwrite/);
+    // Writing over a directory that already has files is not the safe default.
+    expect(args.initialValue).toBe(false);
+  });
+
+  it("cancels when the confirmation is declined", async () => {
+    vi.mocked(confirm).mockResolvedValue(false as never);
+
+    await expect(chooseExistingDirectoryAction(false)).rejects.toBeInstanceOf(
+      CancelledError,
+    );
+  });
+
+  it("cancels when either prompt is interrupted", async () => {
+    vi.mocked(select).mockResolvedValue(CANCEL as never);
+    await expect(chooseExistingDirectoryAction(true)).rejects.toBeInstanceOf(
+      CancelledError,
+    );
+
+    vi.mocked(confirm).mockResolvedValue(CANCEL as never);
+    await expect(chooseExistingDirectoryAction(false)).rejects.toBeInstanceOf(
+      CancelledError,
+    );
+  });
+});
+
+describe("chooseScaffoldTarget", () => {
+  it("leads with managed and reports how many applications are available", async () => {
+    vi.mocked(select).mockResolvedValue("managed" as never);
+
+    await expect(chooseScaffoldTarget(3)).resolves.toBe("managed");
+
+    const args = lastCall(vi.mocked(select));
+    expect(args.initialValue).toBe("managed");
+    expect(args.options?.[0].hint).toContain("3");
+    expect(args.options?.map((o) => o.value)).toEqual(["managed", "local"]);
+  });
+
+  it("returns the local choice", async () => {
+    vi.mocked(select).mockResolvedValue("local" as never);
+    await expect(chooseScaffoldTarget(1)).resolves.toBe("local");
+  });
+
+  it("cancels when interrupted", async () => {
+    vi.mocked(select).mockResolvedValue(CANCEL as never);
+    await expect(chooseScaffoldTarget(1)).rejects.toBeInstanceOf(CancelledError);
+  });
+});
+
+describe("confirmLocalFallback", () => {
+  it("resolves when the developer accepts the local stack", async () => {
+    vi.mocked(confirm).mockResolvedValue(true as never);
+
+    await expect(confirmLocalFallback()).resolves.toBeUndefined();
+
+    expect(lastCall(vi.mocked(confirm)).initialValue).toBe(true);
+  });
+
+  it("cancels rather than scaffolding a stack the developer did not want", async () => {
+    vi.mocked(confirm).mockResolvedValue(false as never);
+    await expect(confirmLocalFallback()).rejects.toBeInstanceOf(CancelledError);
+  });
+
+  it("cancels when interrupted", async () => {
+    vi.mocked(confirm).mockResolvedValue(CANCEL as never);
+    await expect(confirmLocalFallback()).rejects.toBeInstanceOf(CancelledError);
+  });
+});

--- a/src/prompts/initMode.ts
+++ b/src/prompts/initMode.ts
@@ -1,0 +1,89 @@
+import { confirm, select } from "@clack/prompts";
+
+import { CancelledError, orCancel } from "../core/cancel.js";
+
+export type ExistingDirectoryAction = "integrate" | "scaffold";
+
+// A directory with files in it used to force the integrate path, which left a
+// logged-out developer with no way to scaffold anywhere except a completely
+// empty directory. Templates are copied over whatever is already there, so
+// scaffolding into one is offered but never assumed.
+export async function chooseExistingDirectoryAction(
+  canIntegrate: boolean,
+): Promise<ExistingDirectoryAction> {
+  if (!canIntegrate) {
+    const proceed = orCancel(
+      await confirm({
+        message:
+          "This directory is not empty. Scaffold a project here anyway? Starter files overwrite anything with the same name.",
+        initialValue: false,
+      }),
+    );
+    if (!proceed) {
+      throw new CancelledError("Nothing was written.");
+    }
+    return "scaffold";
+  }
+
+  return orCancel(
+    await select({
+      message: "This directory is not empty. What would you like to do?",
+      options: [
+        {
+          value: "integrate",
+          label: "Connect it to a managed application",
+          hint: "writes api/.env, leaves your source alone",
+        },
+        {
+          value: "scaffold",
+          label: "Scaffold a new project here",
+          hint: "starter files overwrite anything with the same name",
+        },
+      ],
+    }),
+  ) as ExistingDirectoryAction;
+}
+
+export type ScaffoldTarget = "managed" | "local";
+
+// Being logged in signals intent, so managed leads, but it is a question rather
+// than a default: a portal session is a poor reason to assume this particular
+// project is not a local experiment.
+export async function chooseScaffoldTarget(
+  appCount: number,
+): Promise<ScaffoldTarget> {
+  return orCancel(
+    await select({
+      message: "How should this project get its auth?",
+      options: [
+        {
+          value: "managed",
+          label: "Connect to a managed application",
+          hint: `${appCount} available`,
+        },
+        {
+          value: "local",
+          label: "Scaffold a local stack",
+          hint: "Docker Compose, runs entirely on your machine",
+        },
+      ],
+      initialValue: "managed",
+    }),
+  ) as ScaffoldTarget;
+}
+
+// Reaching the control plane is the one failure that used to degrade silently:
+// a developer who meant to connect managed got a full local Docker stack with
+// only a warning.
+export async function confirmLocalFallback(): Promise<void> {
+  const proceed = orCancel(
+    await confirm({
+      message:
+        "Could not reach the Seamless control plane. Scaffold a local stack instead?",
+      initialValue: true,
+    }),
+  );
+  if (!proceed) {
+    throw new CancelledError("Nothing was written.");
+  }
+}

--- a/src/prompts/initMode.ts
+++ b/src/prompts/initMode.ts
@@ -12,20 +12,11 @@ export async function chooseExistingDirectoryAction(
   canIntegrate: boolean,
 ): Promise<ExistingDirectoryAction> {
   if (!canIntegrate) {
-    const proceed = orCancel(
-      await confirm({
-        message:
-          "This directory is not empty. Scaffold a project here anyway? Starter files overwrite anything with the same name.",
-        initialValue: false,
-      }),
-    );
-    if (!proceed) {
-      throw new CancelledError("Nothing was written.");
-    }
+    await confirmOverwrite();
     return "scaffold";
   }
 
-  return orCancel(
+  const action = orCancel(
     await select({
       message: "This directory is not empty. What would you like to do?",
       options: [
@@ -42,6 +33,28 @@ export async function chooseExistingDirectoryAction(
       ],
     }),
   ) as ExistingDirectoryAction;
+
+  // The hint on the option is not consent. Writing over a directory a developer
+  // already has work in gets its own confirmation, on every route that reaches
+  // it, so the destructive choice is never one keystroke away.
+  if (action === "scaffold") {
+    await confirmOverwrite();
+  }
+
+  return action;
+}
+
+async function confirmOverwrite(): Promise<void> {
+  const proceed = orCancel(
+    await confirm({
+      message:
+        "This directory is not empty. Scaffold a project here anyway? Starter files overwrite anything with the same name.",
+      initialValue: false,
+    }),
+  );
+  if (!proceed) {
+    throw new CancelledError("Nothing was written.");
+  }
 }
 
 export type ScaffoldTarget = "managed" | "local";


### PR DESCRIPTION
Closes #132.

`init` decided what to do from implicit state and never asked. This makes it ask, and resolves what
is possible before the first prompt.

## Managed is offered, not assumed

A portal session used to make managed the default silently, with `--local` as the only escape and no
way to learn you needed it until after the template prompts. Being signed in signals intent, but it
is a poor reason to assume this particular project is not a local experiment.

When the account has a provisioned application, `init` now asks: connect a managed application, or
scaffold a local stack. Managed leads and is the initial value.

## No more dead end

`scaffoldManaged` asked for web and api templates, then called `listApplications`, then threw
`NoApplicationsError`. Two prompts and a registry fetch to be told to go to the browser, with no way
to continue but re-running with `--local`.

Applications are now resolved in `scaffold()` before any prompt and passed down, so an account with
nothing connectable says why and continues to a local scaffold. The message distinguishes two cases
the old error conflated:

- no applications: names the dashboard
- applications present but none with a URL: says they are still provisioning

The second was actively wrong before, telling someone mid-provision to go create an application they
already had.

## Non-empty directories

`init` routed on `readdirSync(root).length === 0` before anything else, so a directory holding a
`README` or a `.git` could only ever be integrated. A logged-out developer got "Existing project
detected. Log in first" and nothing else, with no way to scaffold there at all.

It now asks. With something to connect that is integrate versus scaffold-here; without, it is a
confirmation to scaffold here, defaulting to no. Both paths say that starter files overwrite anything
with the same name, which is true (`copyInto` does a plain `writeFileSync`) and was never surfaced.

## Unreachable control plane

Previously degraded to a full local Docker stack with only a warning. Now confirms first.

## Flags

`--local` skips the control plane entirely (`createPortalClient` is never called). `--app <id>` is
explicit managed intent and skips both new prompts, including the directory question, and still fails
rather than falling back when there is no session. All three are covered by tests.

## Testing

`npm run build` and `npm test` pass (697 passed, 4 skipped). `npm run coverage` holds: 99.37% lines,
96.39% branches, 99.68% functions, with `initMode.ts` at 100%.

`initMode.test.ts` covers the prompts directly, including that the overwrite warning is present, that
the non-empty confirmation defaults to no, and that every prompt cancels to `CancelledError`. A new
`init mode selection` block in `init.test.ts` covers the routing: the managed/local question and both
answers, the two no-connectable messages, `--app` and `--local` skipping the prompts, integrate being
offered only when there is something to connect, and scaffolding into a non-empty directory.

Not yet run against the live portal.

## Follow-up not in scope

Connecting managed still writes no database configuration, so a managed scaffold's `api` cannot run
`npm run dev` as-is. That is the gap we identified earlier and is worth its own issue.
