### PR TITLE
fix: publish generated compose ports on loopback only

### DIFF
--- a/.changeset/loopback-ports.md
+++ b/.changeset/loopback-ports.md
@@ -1,0 +1,12 @@
+---
+"seamless-cli": patch
+---
+
+Generated compose files now publish every port on `127.0.0.1` instead of all interfaces. A scaffolded
+stack was reachable from any machine on the same network, which mattered most for the auth server:
+it is configured with `ALLOW_UNCREDENTIALED_DELIVERY_SECRETS=true` so `seamless login --local` can
+read OTP codes from the response, and that opt-in is honored before any service-token check. Anyone
+on the LAN could request a code for any user of the stack and read it. Postgres was exposed on the
+same terms, with the fixed credentials the compose file ships.
+
+Local development is unchanged: the browser, the CLI, and inter-container traffic all still work.

--- a/src/generators/auth/auth.test.ts
+++ b/src/generators/auth/auth.test.ts
@@ -116,5 +116,10 @@ describe("generateAuthServer docker mode", () => {
     expect(compose).toContain(`"${shared.apiToken}"`);
     expect(compose).toContain("volumes:\n  pgdata:");
     expect(compose.endsWith("\n")).toBe(true);
+
+    // The auth-only compose publishes on loopback for the same reason as the
+    // full stack: this instance returns OTP codes in the response body.
+    expect(compose).toContain('- "127.0.0.1:5432:5432"');
+    expect(compose).toContain('- "127.0.0.1:5312:5312"');
   });
 });

--- a/src/generators/auth/auth.ts
+++ b/src/generators/auth/auth.ts
@@ -58,13 +58,14 @@ async function setupDockerAuth(root: string) {
   const { env, shared } = buildAuthEnv(parsed, "docker");
   const envBlock = envToDockerBlock(env);
 
-  const dockerCompose = `
+  const dockerCompose = `# Ports are published on 127.0.0.1 so this stack is reachable from this machine
+# only. See the note in the full-stack compose for why that matters here.
 services:
   db:
     image: ${POSTGRES_IMAGE}
     container_name: seamless-db
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_USER: myuser
       POSTGRES_PASSWORD: mypassword
@@ -81,7 +82,7 @@ services:
     image: ${SEAMLESS_AUTH_API_IMAGE}
     container_name: seamless-auth
     ports:
-      - "5312:5312"
+      - "127.0.0.1:5312:5312"
     environment:
 ${envBlock}
     depends_on:

--- a/src/generators/docker/docker.test.ts
+++ b/src/generators/docker/docker.test.ts
@@ -226,6 +226,39 @@ describe("generateDockerCompose", () => {
     expect(compose.endsWith("\n")).toBe(true);
   });
 
+  // Publishing on 0.0.0.0 put the auth server on the LAN, and it is configured to
+  // hand back OTP codes in the response for local login.
+  it("publishes every port on loopback only", async () => {
+    writeAuthEnvFixture(tmpDir, "SEAMLESS_JWKS_ACTIVE_KID");
+
+    await generateDockerCompose(tmpDir, {
+      authMode: "local",
+      adminMode: "image",
+    });
+
+    const compose = fs.readFileSync(
+      path.join(tmpDir, "docker-compose.yml"),
+      "utf-8",
+    );
+
+    for (const mapping of [
+      "127.0.0.1:5432:5432",
+      "127.0.0.1:5312:5312",
+      "127.0.0.1:3000:3000",
+      "127.0.0.1:5173:80",
+      "127.0.0.1:5174:80",
+    ]) {
+      expect(compose).toContain(`- "${mapping}"`);
+    }
+
+    // No mapping escapes the loopback prefix.
+    const published = compose.match(/^\s*- "[^"]*:\d+"$/gm) ?? [];
+    expect(published.length).toBeGreaterThan(0);
+    for (const line of published) {
+      expect(line).toContain('"127.0.0.1:');
+    }
+  });
+
   it("omits the admin container in API-served mode and trims 5174 from the api CORS origins", async () => {
     writeAuthEnvFixture(tmpDir, "SEAMLESS_JWKS_ACTIVE_KID");
 

--- a/src/generators/docker/docker.ts
+++ b/src/generators/docker/docker.ts
@@ -57,13 +57,16 @@ async function buildCompose(
   const includeAdminContainer = adminMode === "image" || adminMode === "source";
 
   return {
-    compose: `
+    compose: `# Ports are published on 127.0.0.1 so this stack is reachable from this machine
+# only. The auth server is configured to return OTP codes in the response for
+# local login, which would otherwise be an authentication bypass for anyone on
+# the same network. Drop the 127.0.0.1 prefix only if you know you want that.
 services:
   db:
     image: ${POSTGRES_IMAGE}
     container_name: seamless-db
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_USER: myuser
       POSTGRES_PASSWORD: mypassword
@@ -111,7 +114,7 @@ async function authService(
       context: ./auth
       dockerfile: Dockerfile.dev
     ports:
-      - "5312:5312"
+      - "127.0.0.1:5312:5312"
     env_file:
       - ./auth/.env
     environment:
@@ -147,7 +150,7 @@ function apiService(shared: any, adminMode: AdminMode) {
     container_name: api
     build: ./api
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     env_file:
       - ./api/.env
     environment:
@@ -173,7 +176,7 @@ function webService() {
     container_name: web
     build: ./web
     ports:
-      - "5173:80"
+      - "127.0.0.1:5173:80"
     environment:
       API_URL: http://localhost:3000/
     volumes:
@@ -213,7 +216,7 @@ async function authServiceDocker(
     image: ${SEAMLESS_AUTH_API_IMAGE}
     container_name: seamless-auth
     ports:
-      - "5312:5312"
+      - "127.0.0.1:5312:5312"
     environment:
 ${envBlock}
     depends_on:
@@ -231,7 +234,7 @@ function adminService(mode: "image" | "source") {
     container_name: admin
     build: ./admin
     ports:
-      - "5174:80"
+      - "127.0.0.1:5174:80"
     environment:
       API_URL: http://localhost:3000/
       AUTH_MODE: server
@@ -248,7 +251,7 @@ function adminService(mode: "image" | "source") {
     image: ${SEAMLESS_AUTH_ADMIN_DASHBOARD_IMAGE}
     container_name: admin
     ports:
-      - "5174:80"
+      - "127.0.0.1:5174:80"
     environment:
       API_URL: http://localhost:3000/
     depends_on:


### PR DESCRIPTION
Closes #138.

Every port in a generated compose file was published on all interfaces. Docker reads `"5432:5432"`
as `0.0.0.0:5432`, so a scaffolded stack answered anything on the same network: office wifi, a coffee
shop, a conference.

Two of those mattered more than the rest.

**The auth server hands out OTP codes.** `buildAuthEnv` sets
`ALLOW_UNCREDENTIALED_DELIVERY_SECRETS=true` so `seamless login --local` can read the code from the
response without a mail provider, and `canReturnExternalDelivery` honors that opt-in **before** it
looks for a service token. Anyone who could reach port 5312 could request a code for any user of that
stack and read it out of the reply, which is a complete authentication bypass for anyone on the LAN.

**Postgres shipped with fixed credentials.** `myuser` / `mypassword`, written into the compose file by
the CLI, on an open port.

Both generated compose files now bind `127.0.0.1` on every mapping, and each carries a comment saying
why so it does not get quietly reverted.

Nothing about local development changes. The browser reaches `localhost:5173`, the CLI reaches
`localhost:5312`, and containers reach each other by service name over the compose network, none of
which go through the published port. What stops working is reaching the stack from another machine.

## What I did not change

`ALLOW_UNCREDENTIALED_DELIVERY_SECRETS` stays. I had flagged it earlier as possibly broken by
seamless-auth-api `916a3b7` ("require a validated service token for external delivery in all
environments") and possibly redundant now that the express template registers dev messaging handlers.
Reading `externalDelivery.ts` settled it: `canReturnExternalDelivery` returns true on the
uncredentialed opt-in before reaching the service-token path, so `seamless login --local` still works
and the flag is doing real work. The auth server also refuses it under a production `NODE_ENV`. On
loopback its exposure is the developer's own machine, which is the tradeoff it was designed for.

The hardcoded postgres credentials also stay. With the port on loopback they are no longer reachable,
and generating them per project is a separate change with its own compose and env implications.

## Testing

`npm run build` and `npm test` pass (677 passed, 4 skipped). Coverage holds at 99.36% lines, 96.23%
branches.

The new test asserts the specific mappings and then sweeps every published-port line in the file to
confirm none escaped the prefix, so a service added later without the binding fails the suite rather
than slipping through. The auth-only compose has its own assertion.

Worth a manual `docker compose up` on a scaffolded project to confirm the stack still comes up, since
the tests only check the generated YAML.
