### PR TITLE
fix: scope conformance projects by testDir instead of testMatch

### DIFF
--- a/.changeset/quiet-pandas-repeat.md
+++ b/.changeset/quiet-pandas-repeat.md
@@ -1,0 +1,8 @@
+---
+'seamless-cli': patch
+---
+
+Fix conformance project routing when the checkout path contains a directory named with an `api/`
+segment. Playwright applies a `testMatch` regex to the absolute file path, so the `api` project's
+pattern also claimed every adapter and react spec, running browser tests in a project with no
+`baseURL`. Each project now scopes itself with `testDir` instead.

--- a/verify/harness/playwright.config.ts
+++ b/verify/harness/playwright.config.ts
@@ -18,12 +18,17 @@ export default defineConfig({
     ['junit', { outputFile: 'results/junit.xml' }],
     ['html', { outputFolder: 'results/html', open: 'never' }],
   ],
+  // Each project scopes itself with testDir, not testMatch. A testMatch regex is
+  // applied to the absolute path, so `/api\/.*\.spec\.ts$/` also matched every
+  // adapter and react spec whenever the checkout lived under a directory
+  // containing "api/" (the seamless-auth-api conformance run does exactly that),
+  // pulling browser specs into a project with no baseURL.
   projects: [
-    { name: 'api', testMatch: /api\/.*\.spec\.ts$/ },
-    { name: 'adapter', testMatch: /adapter\/.*\.spec\.ts$/ },
+    { name: 'api', testDir: './api' },
+    { name: 'adapter', testDir: './adapter' },
     {
       name: 'react',
-      testMatch: /react\/.*\.spec\.ts$/,
+      testDir: './react',
       use: { ...devices['Desktop Chrome'], baseURL: REACT_URL },
     },
   ],


### PR DESCRIPTION
## Summary

The `seamless-auth-api` conformance run has been failing 7 react browser specs with
`page.goto: Protocol error (Page.navigate): Cannot navigate to invalid URL`. The cause is here, in the harness config, not in the API or the React SDK.

Playwright applies a `testMatch` **regex** to the **absolute** file path. The `api` project used `/api\/.*\.spec\.ts$/`, which is fine when the checkout is `work/seamless-cli/seamless-cli/...`, but the API repo's conformance job checks out to:

```
/home/runner/work/seamless-auth-api/seamless-auth-api/seamless-cli/verify/harness/react/register.spec.ts
```

That path contains an `api/` segment, so the `api` project matched **every** adapter and react spec as well. The react specs then ran in a project with no `baseURL`, and their relative `page.goto('/login')` failed.

The same specs passed in the `react` project in the very same run, so this was only ever spurious duplicate execution, never a real product failure.

## Fix

Each project now scopes itself with `testDir`, which is resolved relative to the config and cannot be perturbed by the checkout location.

## Verification

Listing tests from a normal path and from a path containing an `api/` segment:

| Path | Before | After |
| --- | --- | --- |
| `.../seamless-cli/verify/harness` | 14 api / 5 adapter / 7 react | 14 api / 5 adapter / 7 react |
| `.../seamless-auth-api/seamless-cli/verify/harness` | **26 api / 0 adapter / 0 react** | 14 api / 5 adapter / 7 react |

- `npm run build` clean
- `npm test` 677 passed, 4 skipped

## Note

`verify/` ships in the published package, so this also affected any user running `seamless verify` from a project path containing an `api/` segment, hence the changeset.

This does not fix the `api/adminBootstrap.spec.ts` failure in that same conformance run. That one is real fallout from the admin bootstrap removal in the API and is handled separately.