### PR TITLE
feat: wire the managed bundled database into a scaffolded project

### DIFF
--- a/.changeset/managed-database.md
+++ b/.changeset/managed-database.md
@@ -1,0 +1,22 @@
+---
+"seamless-cli": minor
+---
+
+Connecting a project to a managed application now wires up its bundled database. `init` reads the
+application's database and writes `DATABASE_URL` into `api/.env` as
+`postgres://USER:PASSWORD@host:port/db?sslmode=require`.
+
+The user and password stay as literal placeholders. The control plane only returns them for
+`?reveal=true`, which this CLI never asks for, so a live database credential never reaches the
+developer's disk or terminal: they copy those from the dashboard. Anything printed as a connection
+string has its userinfo masked regardless.
+
+An application whose database is still provisioning produces a warning rather than a failure, and the
+database is read before the service token is rotated so a missing one is never reported against a
+project whose old token has already been invalidated. Running `init` inside an existing project adds
+`DATABASE_URL` only when there is not one already, so a working connection string is never replaced
+by a placeholder.
+
+This needs the templates release that teaches the express starter to read `DATABASE_URL` and
+negotiate TLS. Until `SEAMLESS_TEMPLATES_REF` is bumped to it, the value is computed but the pinned
+starter does not declare the placeholder, so nothing is written.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ What happens:
 - It issues the application's service token from the control plane (the real credential, not a
   locally generated secret) and writes it, the managed auth server URL, and the JWKS key id into
   `api/.env`. The frontend is pointed at the same auth server URL.
+- It reads the application's bundled database and writes `DATABASE_URL` into `api/.env` as
+  `postgres://USER:PASSWORD@host:port/db?sslmode=require`. **The user and password stay as literal
+  placeholders**: the CLI never asks the control plane to reveal them, so no live database credential
+  reaches your disk or your terminal. Copy them from the dashboard. An application whose database is
+  still provisioning gets a warning instead, and the scaffold continues.
 - No local auth server, Docker Compose, or admin dashboard is generated. Auth, users, and OAuth
   providers are managed from the dashboard.
 

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -20,7 +20,11 @@ import {
   openTemplateSource,
 } from "../core/templates.js";
 import { createPortalClient, ReauthRequiredError } from "../core/authClient.js";
-import { listApplications, rotateServiceToken } from "../core/portal.js";
+import {
+  getApplicationDatabase,
+  listApplications,
+  rotateServiceToken,
+} from "../core/portal.js";
 import { selectApplication } from "../prompts/appSelect.js";
 import {
   chooseExistingDirectoryAction,
@@ -91,6 +95,11 @@ vi.mock("../core/authClient.js", () => {
 vi.mock("../core/portal.js", () => ({
   listApplications: vi.fn(),
   rotateServiceToken: vi.fn(),
+  getApplicationDatabase: vi.fn(),
+  buildScaffoldDatabaseUrl: vi.fn(
+    (db: { host: string; port: number; database: string }) =>
+      `postgres://USER:PASSWORD@${db.host}:${db.port}/${db.database}?sslmode=require`,
+  ),
 }));
 vi.mock("../core/config.js", () => ({
   normalizeInstanceUrl: vi.fn((u: string) => `norm:${u}`),
@@ -194,6 +203,7 @@ beforeEach(() => {
   // Default answers for the mode prompts; individual tests override.
   vi.mocked(chooseExistingDirectoryAction).mockResolvedValue("integrate");
   vi.mocked(chooseScaffoldTarget).mockResolvedValue("managed");
+  vi.mocked(getApplicationDatabase).mockResolvedValue(null);
   vi.mocked(confirmLocalFallback).mockResolvedValue(undefined);
 });
 
@@ -929,6 +939,103 @@ describe("init mode selection", () => {
   });
 });
 
+describe("managed database wiring", () => {
+  function connected() {
+    vi.mocked(createPortalClient).mockResolvedValue({
+      profile: { name: "default", instanceUrl: "https://auth" },
+    } as never);
+    vi.mocked(listApplications).mockResolvedValue([app()] as never);
+    vi.mocked(selectApplication).mockResolvedValue(app() as never);
+    vi.mocked(rotateServiceToken).mockResolvedValue("svc-token");
+    vi.mocked(openTemplateSource).mockResolvedValue(makeSource() as never);
+    vi.mocked(runManagedTemplatePrompts).mockResolvedValue({
+      webTemplateId: "web-basic",
+      apiTemplateId: "api-express",
+    } as never);
+  }
+
+  it("writes a placeholder connection string into the scaffold context", async () => {
+    connected();
+    vi.mocked(getApplicationDatabase).mockResolvedValue({
+      host: "db.example.com",
+      port: 5432,
+      database: "tenant",
+    } as never);
+
+    await runCLI(undefined, [], { appId: "app-1" });
+
+    expect(applyTemplateEnv).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        databaseUrl:
+          "postgres://USER:PASSWORD@db.example.com:5432/tenant?sslmode=require",
+      }),
+    );
+  });
+
+  // Mid-deploy applications have no database yet, which is a warning rather
+  // than a reason to fail a scaffold that is otherwise fine.
+  it("warns and carries an empty string when none is provisioned", async () => {
+    connected();
+    vi.mocked(getApplicationDatabase).mockResolvedValue(null as never);
+
+    await runCLI(undefined, [], { appId: "app-1" });
+
+    expect(out()).toContain("No managed database is available");
+    expect(applyTemplateEnv).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ databaseUrl: "" }),
+    );
+    expect(printManagedSuccessOutput).toHaveBeenCalled();
+  });
+
+  // Reading it after rotation would mean reporting a missing database against a
+  // project whose token had already been invalidated.
+  it("reads the database before the token is rotated", async () => {
+    connected();
+    const order: string[] = [];
+    vi.mocked(getApplicationDatabase).mockImplementation(async () => {
+      order.push("database");
+      return null as never;
+    });
+    vi.mocked(rotateServiceToken).mockImplementation(async () => {
+      order.push("rotate");
+      return "svc-token";
+    });
+
+    await runCLI(undefined, [], { appId: "app-1" });
+
+    expect(order).toEqual(["database", "rotate"]);
+  });
+
+  it("scaffolds a local stack with no connection string", async () => {
+    vi.mocked(createPortalClient).mockRejectedValue(
+      new ReauthRequiredError("no session"),
+    );
+    vi.mocked(openTemplateSource).mockResolvedValue(makeSource() as never);
+    vi.mocked(runProjectSetupPrompts).mockResolvedValue({
+      webTemplateId: "web-basic",
+      apiTemplateId: "api-express",
+      authMode: "docker",
+      adminMode: "image",
+      useDocker: true,
+      ownerEmail: "dev@example.com",
+    } as never);
+    vi.mocked(generateDockerCompose).mockResolvedValue({} as never);
+
+    await runCLI(undefined, []);
+
+    expect(getApplicationDatabase).not.toHaveBeenCalled();
+    expect(applyTemplateEnv).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ databaseUrl: "" }),
+    );
+  });
+});
+
 describe("integrateExistingProject", () => {
   beforeEach(() => {
     // Non-empty directory triggers the existing-project path.
@@ -983,6 +1090,49 @@ describe("integrateExistingProject", () => {
       }),
     );
     expect(out()).toContain("Updated");
+  });
+
+  it("adds DATABASE_URL to an existing project, but never overwrites one", async () => {
+    vi.mocked(createPortalClient).mockResolvedValue({
+      profile: { name: "default", instanceUrl: "https://auth" },
+    } as never);
+    vi.mocked(listApplications).mockResolvedValue([app()] as never);
+    vi.mocked(selectApplication).mockResolvedValue(app() as never);
+    vi.mocked(rotateServiceToken).mockResolvedValue("svc-token");
+    vi.mocked(getApplicationDatabase).mockResolvedValue({
+      host: "db.example.com",
+      port: 5432,
+      database: "tenant",
+    } as never);
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+
+    // An existing project may already hold a working connection string,
+    // credentials and all; a placeholder must not replace it.
+    vi.mocked(parseEnv).mockReturnValue({
+      DATABASE_URL: "postgres://real:creds@db.example.com:5432/tenant",
+    } as never);
+
+    await runCLI(undefined, []);
+
+    expect(writeEnv).toHaveBeenCalledWith(
+      "/work/api/.env",
+      expect.objectContaining({
+        DATABASE_URL: "postgres://real:creds@db.example.com:5432/tenant",
+      }),
+    );
+
+    vi.mocked(writeEnv).mockClear();
+    vi.mocked(parseEnv).mockReturnValue({} as never);
+
+    await runCLI(undefined, []);
+
+    expect(writeEnv).toHaveBeenCalledWith(
+      "/work/api/.env",
+      expect.objectContaining({
+        DATABASE_URL:
+          "postgres://USER:PASSWORD@db.example.com:5432/tenant?sslmode=require",
+      }),
+    );
   });
 
   it("preserves existing api/.env values when the file is present", async () => {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -41,6 +41,8 @@ import { getPortalSession, normalizeInstanceUrl } from "../core/config.js";
 import { parseEnv, writeEnv } from "../core/env.js";
 import { generateSecret } from "../core/secrets.js";
 import {
+  buildScaffoldDatabaseUrl,
+  getApplicationDatabase,
   listApplications,
   rotateServiceToken,
   type PortalApp,
@@ -194,6 +196,27 @@ async function scaffold(
   await scaffoldLocal(root, projectName, aliases);
 }
 
+// The bundled database as a connection string with placeholder credentials, or
+// an empty string when the control plane has not provisioned one yet. Never
+// requests ?reveal=true, so no live credential reaches this machine.
+async function resolveDatabaseUrl(
+  client: AuthClient,
+  app: PortalApp,
+): Promise<string> {
+  const database = await getApplicationDatabase(client, app.id);
+
+  if (!database) {
+    console.log(
+      kleur.yellow(
+        `No managed database is available for "${app.name}" yet. Set DATABASE_URL in api/.env once it finishes provisioning.`,
+      ),
+    );
+    return "";
+  }
+
+  return buildScaffoldDatabaseUrl(database);
+}
+
 // The old message told an account whose only application was still provisioning
 // that it had none and should create one.
 function noConnectableMessage(hasProvisioning: boolean): string {
@@ -257,6 +280,11 @@ async function scaffoldManaged(
     await source.copyInto(entry, dir);
   }
 
+  // Read before rotating: a database that is not provisioned yet is a warning,
+  // not a failure, and finding that out after the token is rotated would mean
+  // reporting it against a half-wired project.
+  const databaseUrl = await resolveDatabaseUrl(client, app);
+
   const serviceToken = await issueServiceToken(client, app);
 
   const authServerUrl = normalizeInstanceUrl(app.domain);
@@ -273,6 +301,7 @@ async function scaffoldManaged(
       // A managed instance hosts its own dashboard, so the app API does not proxy
       // the console. Keeps the template's SERVE_ADMIN_CONSOLE gate off.
       serveAdminConsole: "false",
+      databaseUrl,
     };
 
     for (const { manifest, dir } of selected) {
@@ -301,6 +330,7 @@ async function scaffoldManaged(
       apiFramework: apiEntry.framework,
       authServerUrl,
       appName: app.name,
+      databaseUrl,
     });
   } catch (err) {
     console.error(
@@ -377,6 +407,9 @@ async function scaffoldLocal(
     apiToken: sharedConfig.apiToken,
     jwksKid: sharedConfig.kid,
     serveAdminConsole: answers.adminMode === "api" ? "true" : "false",
+    // The local stack runs its own postgres from the compose file, which the
+    // starter reaches through its discrete DB_* values.
+    databaseUrl: "",
   };
 
   for (const { manifest, dir } of selected) {
@@ -420,6 +453,11 @@ async function integrateExistingProject(
 ) {
   const app = await selectApplication(apps, opts.appId);
 
+  // Read before rotating: a database that is not provisioned yet is a warning,
+  // not a failure, and finding that out after the token is rotated would mean
+  // reporting it against a half-wired project.
+  const databaseUrl = await resolveDatabaseUrl(client, app);
+
   const serviceToken = await issueServiceToken(client, app);
 
   const authServerUrl = normalizeInstanceUrl(app.domain);
@@ -433,7 +471,7 @@ async function integrateExistingProject(
   // The token is already rotated (old one invalidated); if the write fails, print
   // it so the app can be re-wired by hand rather than left bricked.
   try {
-    wireApiEnv(apiDir, authServerUrl, serviceToken);
+    wireApiEnv(apiDir, authServerUrl, serviceToken, databaseUrl);
   } catch (err) {
     console.error(
       kleur.red(
@@ -457,6 +495,7 @@ function wireApiEnv(
   apiDir: string,
   authServerUrl: string,
   serviceToken: string,
+  databaseUrl: string,
 ) {
   const envPath = path.join(apiDir, ".env");
   const values = fs.existsSync(envPath) ? parseEnv(envPath) : {};
@@ -466,6 +505,11 @@ function wireApiEnv(
   values.JWKS_KID = values.JWKS_KID || MANAGED_JWKS_KID;
   values.COOKIE_SIGNING_KEY =
     values.COOKIE_SIGNING_KEY || generateSecret(32);
+  // Never overwritten: an existing project may already hold a working
+  // connection string, credentials and all, and this one carries placeholders.
+  if (databaseUrl && !values.DATABASE_URL) {
+    values.DATABASE_URL = databaseUrl;
+  }
 
   fs.mkdirSync(apiDir, { recursive: true });
   writeEnv(envPath, values);

--- a/src/core/output.test.ts
+++ b/src/core/output.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { printManagedSuccessOutput, printSuccessOutput } from "./output.js";
+import {
+  maskDatabaseUrl,
+  printManagedSuccessOutput,
+  printSuccessOutput,
+} from "./output.js";
 
 let logSpy: ReturnType<typeof vi.spyOn>;
 
@@ -189,6 +193,8 @@ describe("printManagedSuccessOutput", () => {
       apiFramework: "fastify",
       authServerUrl: "https://auth.example.com",
       appName: "Acme App",
+      databaseUrl:
+        "postgres://USER:PASSWORD@db.example.com:5432/tenant?sslmode=require",
     });
 
     const out = allLogs();
@@ -243,6 +249,20 @@ describe("printManagedSuccessOutput", () => {
     expect(out).not.toContain("# Web app");
     expect(out).toContain(
       "Sign in from the web app to confirm the session resolves.",
+    );
+  });
+});
+
+describe("maskDatabaseUrl", () => {
+  it("masks userinfo in anything printed as a connection string", () => {
+    expect(
+      maskDatabaseUrl("postgres://real:s3cret@db.example.com:5432/tenant"),
+    ).toBe("postgres://****:****@db.example.com:5432/tenant");
+  });
+
+  it("leaves a URL without userinfo alone", () => {
+    expect(maskDatabaseUrl("postgres://db.example.com:5432/tenant")).toBe(
+      "postgres://db.example.com:5432/tenant",
     );
   });
 });

--- a/src/core/output.ts
+++ b/src/core/output.ts
@@ -180,9 +180,16 @@ export function printManagedSuccessOutput(config: {
   apiFramework: string | null;
   authServerUrl: string;
   appName: string;
+  databaseUrl?: string;
 }) {
-  const { projectName, webFramework, apiFramework, authServerUrl, appName } =
-    config;
+  const {
+    projectName,
+    webFramework,
+    apiFramework,
+    authServerUrl,
+    appName,
+    databaseUrl,
+  } = config;
 
   const title = kleur.bold().cyan("SEAMLESS");
 
@@ -224,6 +231,22 @@ export function printManagedSuccessOutput(config: {
   console.log("");
 
   console.log(kleur.bold("Next steps:\n"));
+
+  // The placeholders are the only thing standing between the scaffold and a
+  // working database, so they lead rather than sitting in a footnote.
+  if (databaseUrl) {
+    console.log(kleur.dim("  # Database"));
+    console.log(
+      "  Fill in the credentials in " +
+        kleur.cyan("api/.env") +
+        kleur.dim(" (DATABASE_URL):"),
+    );
+    console.log("  " + kleur.dim(maskDatabaseUrl(databaseUrl)));
+    console.log(
+      kleur.dim("  Copy the user and password from the dashboard.\n"),
+    );
+  }
+
   if (apiFramework) {
     console.log(kleur.dim("  # API server"));
     console.log("  cd api && npm install && npm run dev\n");
@@ -254,6 +277,13 @@ export function printManagedSuccessOutput(config: {
   );
 
   console.log(kleur.bold().green("Setup complete.\n"));
+}
+
+// Belt and braces: the CLI only ever holds a placeholder connection string, but
+// anything printed as a connection string gets its userinfo masked so a real one
+// pasted through here could never be echoed back in full.
+export function maskDatabaseUrl(url: string): string {
+  return url.replace(/\/\/[^@/]*@/, "//****:****@");
 }
 
 function formatFramework(name: string) {

--- a/src/core/portal.test.ts
+++ b/src/core/portal.test.ts
@@ -6,7 +6,9 @@ import type { Profile } from "./config.js";
 import {
   DEFAULT_PORTAL_API_URL,
   PortalError,
+  buildScaffoldDatabaseUrl,
   getApplication,
+  getApplicationDatabase,
   getPortalApiUrl,
   listApplications,
   resolveAppInstanceUrl,
@@ -259,6 +261,102 @@ describe("getApplication", () => {
     const idless = fakeClient([response(200, { application: { name: "x" } })]);
     await expect(getApplication(idless.client, "app-1")).rejects.toThrow(
       /unexpected response/,
+    );
+  });
+});
+
+describe("getApplicationDatabase", () => {
+  beforeEach(() => {
+    process.env.SEAMLESS_PORTAL_API_URL = "http://localhost:5001";
+  });
+  afterEach(() => {
+    delete process.env.SEAMLESS_PORTAL_API_URL;
+  });
+
+  it("reads the masked database without asking for credentials", async () => {
+    const { client, calls } = fakeClient([
+      response(200, {
+        database: {
+          host: "db.example.com",
+          port: 5432,
+          database: "tenant",
+          username: "tenant_user",
+          engine: "postgres",
+          connectionString:
+            "postgres://tenant_user:****@db.example.com:5432/tenant?sslmode=require",
+          masked: true,
+        },
+      }),
+    ]);
+
+    const db = await getApplicationDatabase(client, "app-1");
+
+    // No reveal=true anywhere: the password never reaches this machine.
+    expect(calls[0]).toEqual({
+      method: "GET",
+      path: "http://localhost:5001/applications/app-1/database",
+    });
+    expect(db).toEqual({
+      host: "db.example.com",
+      port: 5432,
+      database: "tenant",
+      engine: "postgres",
+    });
+    // The username is returned by the control plane and deliberately dropped.
+    expect(db as Record<string, unknown>).not.toHaveProperty("username");
+    expect(db as Record<string, unknown>).not.toHaveProperty("password");
+  });
+
+  it("defaults a missing or unusable port to 5432", async () => {
+    const { client } = fakeClient([
+      response(200, { database: { host: "h", database: "d", port: "nope" } }),
+    ]);
+    await expect(getApplicationDatabase(client, "app-1")).resolves.toMatchObject(
+      { port: 5432 },
+    );
+  });
+
+  // Normal for an application mid-deploy, so it must not fail a scaffold.
+  it("returns null when no database is provisioned yet", async () => {
+    const { client } = fakeClient([response(404, null)]);
+    await expect(getApplicationDatabase(client, "app-1")).resolves.toBeNull();
+  });
+
+  it("returns null for a payload it cannot use", async () => {
+    const missing = fakeClient([response(200, {})]);
+    await expect(
+      getApplicationDatabase(missing.client, "app-1"),
+    ).resolves.toBeNull();
+
+    const partial = fakeClient([response(200, { database: { host: "h" } })]);
+    await expect(
+      getApplicationDatabase(partial.client, "app-1"),
+    ).resolves.toBeNull();
+  });
+
+  it("treats a 401 or 403 as an authorization failure", async () => {
+    const { client } = fakeClient([response(403, null)]);
+    await expect(
+      getApplicationDatabase(client, "app-1"),
+    ).rejects.toBeInstanceOf(PortalError);
+  });
+
+  it("reports other failures with the status code", async () => {
+    const { client } = fakeClient([response(500, null)]);
+    await expect(getApplicationDatabase(client, "app-1")).rejects.toThrow(/500/);
+  });
+});
+
+describe("buildScaffoldDatabaseUrl", () => {
+  it("carries placeholders instead of credentials, and requires TLS", () => {
+    const url = buildScaffoldDatabaseUrl({
+      host: "db.example.com",
+      port: 5432,
+      database: "tenant",
+    });
+
+    expect(url).toBe(
+      "postgres://USER:PASSWORD@db.example.com:5432/tenant?sslmode=require",
     );
   });
 });

--- a/src/core/portal.ts
+++ b/src/core/portal.ts
@@ -185,6 +185,71 @@ export async function getApplication(
   return app;
 }
 
+// The bundled database the control plane provisions alongside a managed
+// application, as much of it as the CLI is willing to hold.
+//
+// The username and password are deliberately absent. The control plane only
+// returns them for `?reveal=true`, which this CLI never asks for, so a live
+// database credential never reaches the developer's disk or terminal through
+// here. They copy those from the dashboard themselves.
+export interface PortalDatabase {
+  host: string;
+  port: number;
+  database: string;
+  engine?: string;
+}
+
+// Reads the bundled database. Returns null when the control plane has not
+// provisioned one yet, which is a normal state for an application mid-deploy
+// and must not fail a scaffold.
+export async function getApplicationDatabase(
+  client: AuthClient,
+  appId: string,
+): Promise<PortalDatabase | null> {
+  const url = joinUrl(
+    getPortalApiUrl(),
+    `/applications/${encodeURIComponent(appId)}/database`,
+  );
+  const res = await client.get<{ database?: unknown }>(url);
+
+  if (res.status === 401 || res.status === 403) {
+    throw unauthorized("read this application's database");
+  }
+  if (res.status === 404) {
+    return null;
+  }
+  if (!res.ok) {
+    throw new PortalError(
+      `Could not read the database for "${appId}" (${res.status}).`,
+    );
+  }
+
+  const raw = res.data?.database;
+  if (!raw || typeof raw !== "object") return null;
+
+  const record = raw as Record<string, unknown>;
+  const host = str(record, "host");
+  const database = str(record, "database");
+  if (!host || !database) return null;
+
+  const port = Number(record.port);
+
+  return {
+    host,
+    database,
+    port: Number.isFinite(port) && port > 0 ? port : 5432,
+    engine: str(record, "engine"),
+  };
+}
+
+// The connection string written into a scaffolded api/.env. USER and PASSWORD
+// stay as literal placeholders: obvious to spot, obvious to replace, and
+// impossible to mistake for working credentials. sslmode=require matches what
+// the control plane hands out, and is what makes the starter negotiate TLS.
+export function buildScaffoldDatabaseUrl(db: PortalDatabase): string {
+  return `postgres://USER:PASSWORD@${db.host}:${db.port}/${db.database}?sslmode=require`;
+}
+
 // Issues (rotates) the application's service token. The control plane only ever
 // returns a raw token at rotation time (it is stored write-once), so this is the
 // real credential flow: the token the auth instance already recognizes for this

--- a/src/core/templates.ts
+++ b/src/core/templates.ts
@@ -58,6 +58,10 @@ export interface ScaffoldContext {
   // "true" when the app API should serve the admin console at /console, "false"
   // when the console is hosted elsewhere (a standalone container) or omitted.
   serveAdminConsole?: string;
+  // Connection string for a managed bundled database, with placeholder
+  // credentials. Empty for a local stack, whose starter falls back to its
+  // discrete DB_* values.
+  databaseUrl?: string;
 }
 
 // Build artifacts and local-only files that must never be copied into a scaffold,
@@ -250,6 +254,7 @@ function resolveToken(token: string, ctx: ScaffoldContext): string {
     apiToken: ctx.apiToken,
     jwksKid: ctx.jwksKid,
     serveAdminConsole: ctx.serveAdminConsole,
+    databaseUrl: ctx.databaseUrl,
   };
 
   if (token in known) {


### PR DESCRIPTION
Pairs with fells-code/seamless-templates#22. Together they close the managed-database gap: a managed
scaffold had no database configuration at all, so its `api` fell back to `DB_*` values pointing at a
postgres that only exists in the local compose stack.

## What it does

`init` reads the application's bundled database and writes into `api/.env`:

```
DATABASE_URL=postgres://USER:PASSWORD@host:5432/dbname?sslmode=require
```

`sslmode=require` is what makes the starter negotiate TLS, which a managed database requires for
external connections.

## Credentials never reach this machine

`USER` and `PASSWORD` are literal placeholders, and that is enforced at the source rather than by
formatting:

- The control plane returns the real credentials only for `?reveal=true`. **This CLI never sends
  it**, so the password is never in a response we hold.
- The masked response still carries the `username`. `getApplicationDatabase` deliberately does not
  map it, so it cannot leak by accident through a later change.
- `maskDatabaseUrl` scrubs userinfo from anything printed as a connection string, so even a real one
  reaching that path could not be echoed in full.

Placeholders rather than an omitted userinfo section on purpose: `postgres://host/db` parses fine and
would fail later with a confusing authentication error, while `USER:PASSWORD` is obvious to spot and
obvious to replace.

## Ordering and idempotence

The database is read **before** the service token is rotated. Rotation invalidates the previous
token, so discovering a missing database afterwards would mean reporting it against a project that
had already been half-rewired.

A database that is not provisioned yet (a 404, normal mid-deploy) is a warning and an empty value,
not a failed scaffold.

Running `init` inside an existing project adds `DATABASE_URL` only when there is not one already, so
a working connection string with real credentials is never replaced by a placeholder.

## This is inert until the templates ref is bumped

The pinned `v0.4.0` starter does not declare `{{databaseUrl}}`, and `applyTemplateEnv` only writes
keys the manifest declares, so the value is computed and nothing is written. Once
seamless-templates#22 is released, bumping `SEAMLESS_TEMPLATES_REF` turns it on. Deliberate: shipping
the ref bump here would point at a tag that does not exist.

To try it before then, point `SEAMLESS_TEMPLATES_DIR` at a local checkout of that branch.

## Testing

`npm run build` and `npm test` pass (691 passed, 4 skipped). Coverage holds: 99.37% lines, 96.28%
branches, with `portal.ts` and `output.ts` at 100%.

Tests cover the request carrying no `reveal`, the username and password being absent from the mapped
result, a bad port defaulting to 5432, 404 and unusable payloads returning null, 401/403 and 5xx
handling, the placeholder URL shape, the local path passing an empty string, the read-before-rotate
ordering, and both existing-project branches (adds when absent, preserves when present).

Not tested against a live managed database. The open question from the templates PR applies here too:
if the tenant certificate does not chain to a public CA, connections will fail until
`DB_SSL_REJECT_UNAUTHORIZED=false` is set.
