### PR TITLE
chore: scaffold from seamless-templates v0.5.0

### DIFF
--- a/.changeset/templates-ref-v0-5-0.md
+++ b/.changeset/templates-ref-v0-5-0.md
@@ -1,0 +1,8 @@
+---
+"seamless-cli": patch
+---
+
+Scaffold from seamless-templates v0.5.0, which teaches the express starter to read `DATABASE_URL` and
+negotiate TLS when the connection string carries `sslmode=require`. This is what turns on the managed
+bundled database wiring: the CLI already computed the connection string, but the pinned v0.4.0
+starter did not declare the placeholder, so nothing was written.

--- a/src/core/images.ts
+++ b/src/core/images.ts
@@ -13,4 +13,4 @@ export const SEAMLESS_AUTH_ADMIN_DASHBOARD_IMAGE = `ghcr.io/fells-code/seamless-
 // SEAMLESS_TEMPLATES_REF, or point at a local checkout with SEAMLESS_TEMPLATES_DIR.
 export const SEAMLESS_TEMPLATES_REPO = "fells-code/seamless-templates";
 
-export const SEAMLESS_TEMPLATES_REF = "v0.4.0";
+export const SEAMLESS_TEMPLATES_REF = "v0.5.0";


### PR DESCRIPTION
Bumps `SEAMLESS_TEMPLATES_REF` from `v0.4.0` to `v0.5.0`, the release that carries the express
starter's `DATABASE_URL` and TLS support (fells-code/seamless-templates#22).

This is the step that makes #141 take effect. The CLI already computed the managed connection string,
but `applyTemplateEnv` only writes keys the manifest declares, and `v0.4.0` did not declare
`{{databaseUrl}}`, so nothing was written.

## Verified against the published tag

Not a fixture: I ran the real `openTemplateSource` at `v0.5.0`, copied the express starter into temp
directories, and applied `applyTemplateEnv` with both scaffold contexts.

- The manifest declares `DATABASE_URL: {{databaseUrl}}`.
- A managed context writes
  `DATABASE_URL=postgres://USER:PASSWORD@db.example.com:5432/tenant?sslmode=require`.
- A local context writes `DATABASE_URL=`, so the starter falls back to its discrete `DB_*` values, as
  the compose stack needs.
- `src/lib/databaseUrl.ts` is present in the copied template.

That empty-local case was the one that could have broken the existing flow: an unresolved placeholder
throws, so a missing `databaseUrl` on the local path would have failed every local scaffold.

`npm run build` and `npm test` pass (691 passed, 4 skipped), coverage unchanged at 99.37% lines.

## Still open

`cliMin` in the templates manifest is still `0.10.0`. Raising it needs another templates release and
buys little, since the CLI only ever fetches the ref it pins. Worth folding into the next templates
change rather than releasing for it alone.

The TLS certificate question stands: if a tenant's Postgres presents a certificate that does not chain
to a public CA, managed connections fail until `DB_SSL_REJECT_UNAUTHORIZED=false` is set. First live
trial will tell us, and if it does not chain we should ship the CA rather than flip the default.
