### PR TITLE
feat: add a non-interactive seamless init

### DIFF
--- a/.changeset/init-non-interactive.md
+++ b/.changeset/init-non-interactive.md
@@ -1,0 +1,23 @@
+---
+"seamless-cli": minor
+---
+
+Add a non-interactive `seamless init`. `--yes` (`-y`) answers every question with the option the
+prompt marks as recommended, so a scaffold runs from CI, a Dockerfile, or a script with no terminal
+attached:
+
+```bash
+seamless init my-app --local --yes --email=you@example.com
+```
+
+Each question also gets its own flag, honored with or without `--yes`: `--web=<id|alias>` and
+`--api=<id|alias>` choose the starters, `--email=<address>` sets the owner who becomes the admin,
+`--auth=<docker|local>` picks how the auth server runs, and `--admin=<api|image|source|none>` picks
+where the admin console is hosted. Unspecified values fall back to the recommended option, except
+the owner email, which has no safe default and is taken from `--email` or the portal session.
+
+`--yes` deliberately stops rather than guessing in three places. Choosing between a managed
+application and a local stack needs `--app <id>` or `--local`. Scaffolding into a directory that is
+not empty needs `--force`, since starter files overwrite anything with the same name. Rotating a
+managed application's existing service token needs `--force` too, because it breaks whatever is
+already deployed on the old one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,13 @@ The entry point is [src/index.ts](src/index.ts), which dispatches to a command m
     registry, so no per-flag code. `resolveTemplateAliases` runs in `runCLI` before the project
     directory is created and before the non-empty-directory confirmation, so an unknown flag can
     never route through a destructive prompt on its way to an error.
+  - `--yes` runs the whole thing without prompting: every question has a flag (`--web`, `--api`,
+    `--email`, `--auth`, `--admin`) and anything unspecified falls back to the option the prompt
+    marks "(recommended)". `--yes` is never enough for a destructive step: overwriting a non-empty
+    directory and rotating an existing service token both require `--force`, and choosing between a
+    managed application and a local stack requires `--app` or `--local`. Flag parsing lives in
+    `parseInitArgs` ([src/index.ts](src/index.ts)); everything it produces is validated in `runCLI`
+    before a directory is created.
   - **templates** ([src/commands/templates.ts](src/commands/templates.ts)) lists the registry
     (`seamless templates list [--json]`) so those ids and flags are discoverable without a
     checkout. It reads the same source `init` does and needs no login.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,39 @@ registry `init` does, so `SEAMLESS_TEMPLATES_DIR` and `SEAMLESS_TEMPLATES_REF` a
 
 ---
 
+## Scripting init
+
+`--yes` answers every question with the recommended option instead of prompting, so `init` runs from
+CI, a Dockerfile, or a script with no terminal attached:
+
+```bash
+seamless init my-app --local --yes --email=you@example.com
+```
+
+Each question also has its own flag, honored with or without `--yes`:
+
+| Flag | Question | Default under `--yes` |
+| --- | --- | --- |
+| `--web=<id\|alias>` | Web example | first selectable web template |
+| `--api=<id\|alias>` | Backend framework | first selectable api template |
+| `--email=<address>` | Owner email (becomes the admin) | required |
+| `--auth=<docker\|local>` | How the auth server runs | `docker` |
+| `--admin=<api\|image\|source\|none>` | Where the admin console is hosted | `api` |
+
+Two things `--yes` deliberately will not decide for you:
+
+- **Managed or local.** With a portal session and neither `--local` nor `--app <id>`, `init` stops
+  rather than guessing where the project's auth lives.
+- **Anything destructive.** Scaffolding into a directory that is not empty (starter files overwrite
+  anything with the same name) and rotating a managed application's existing service token (which
+  breaks whatever is deployed on the old one) both take `--force`, not `--yes`.
+
+`--email` has no safe default, so under `--yes` it is required unless `seamless login` has left a
+portal session to take it from. Templates that would prompt for OAuth provider credentials are
+scaffolded with none configured; add them afterwards with `seamless config oauth-providers add`.
+
+---
+
 ## What gets created
 
 Depending on your selections, the CLI generates a project like this:

--- a/src/commands/helpTopics.ts
+++ b/src/commands/helpTopics.ts
@@ -16,7 +16,10 @@ export interface CommandHelp {
 export const COMMAND_HELP: CommandHelp[] = [
   {
     name: "init",
-    usage: ["seamless init [project-name] [--<example>]"],
+    usage: [
+      "seamless init [project-name] [--<template>]",
+      "seamless init [project-name] --yes [--web=<id>] [--api=<id>] [--email=<address>] [--auth=<mode>] [--admin=<mode>]",
+    ],
     sections: [
       {
         heading: "init [project-name]",
@@ -44,7 +47,35 @@ With a template flag (e.g. --oauth, --react-oauth, --fastify):
     session from seamless login)
 
 --local
-  • Point the generated project at a locally running auth stack`,
+  • Point the generated project at a locally running auth stack
+
+NON-INTERACTIVE
+
+--yes, -y
+  • Answer every remaining question with the recommended option instead of
+    prompting, for CI, a Dockerfile, or a scripted run
+  • Pair it with --local or --app <id>: which stack the project gets is not
+    something --yes will guess
+  • It never stands in for a destructive confirmation (see --force)
+
+--web=<id|alias>, --api=<id|alias>
+  • Choose the web and api starters by name
+  • Default to the first selectable template of that kind in the registry
+
+--email=<address>
+  • The owner address, which becomes the admin when you register
+  • Required under --yes unless a portal session supplies one
+
+--auth=<docker|local>
+  • How the auth server runs (default: docker)
+
+--admin=<api|image|source|none>
+  • Where the admin console is hosted (default: api)
+
+--force
+  • Allow the two destructive steps --yes will not take on its own:
+    scaffolding into a directory that is not empty, and rotating a managed
+    application's existing service token`,
       },
     ],
     examples: [
@@ -54,6 +85,8 @@ With a template flag (e.g. --oauth, --react-oauth, --fastify):
   → Create new project in ./my-app`,
       `seamless init --oauth my-app
   → Create ./my-app from the OAuth example starter`,
+      `seamless init my-app --local --yes --email=you@example.com
+  → Scaffold the recommended local stack with no prompts`,
     ],
   },
   {

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -55,7 +55,10 @@ vi.mock("@clack/prompts", () => ({
   isCancel: vi.fn(() => false),
 }));
 
-vi.mock("../prompts/projectSetup.js", () => ({
+// The mode lists are plain constants init validates flags against, so they come
+// from the real module; only the prompt runners are stubbed.
+vi.mock("../prompts/projectSetup.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../prompts/projectSetup.js")>()),
   runManagedTemplatePrompts: vi.fn(),
   runProjectSetupPrompts: vi.fn(),
 }));
@@ -587,6 +590,7 @@ describe("template alias resolution", () => {
       expect.anything(),
       expect.objectContaining({ webTemplateId: "web-oauth" }),
       undefined,
+      undefined,
     );
   });
 
@@ -608,6 +612,7 @@ describe("template alias resolution", () => {
       expect.anything(),
       expect.objectContaining({ webTemplateId: "web-basic" }),
       undefined,
+      undefined,
     );
   });
 
@@ -616,6 +621,7 @@ describe("template alias resolution", () => {
     expect(runProjectSetupPrompts).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ webTemplateId: "web-oauth" }),
+      undefined,
       undefined,
     );
   });
@@ -1248,5 +1254,213 @@ describe("integrateExistingProject", () => {
 
     expect(rotateServiceToken).not.toHaveBeenCalled();
     expect(writeEnv).not.toHaveBeenCalled();
+  });
+});
+
+describe("non-interactive init (--yes)", () => {
+  function localAnswers(over: Record<string, unknown> = {}) {
+    return {
+      webTemplateId: "web-basic",
+      apiTemplateId: "api-express",
+      authMode: "docker",
+      adminMode: "api",
+      useDocker: true,
+      ownerEmail: "dev@example.com",
+      ...over,
+    } as never;
+  }
+
+  beforeEach(() => {
+    vi.mocked(openTemplateSource).mockResolvedValue(makeSource() as never);
+    vi.mocked(runProjectSetupPrompts).mockResolvedValue(localAnswers());
+    vi.mocked(generateDockerCompose).mockResolvedValue({} as never);
+  });
+
+  it("tells the prompts to answer themselves", async () => {
+    await runCLI(undefined, [], { local: true, yes: true });
+
+    expect(runProjectSetupPrompts).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      undefined,
+      true,
+    );
+  });
+
+  it("passes the answer flags through as preselected answers", async () => {
+    await runCLI(undefined, [], {
+      local: true,
+      yes: true,
+      email: "owner@example.com",
+      auth: "local",
+      admin: "none",
+      web: "web-oauth",
+      api: "api-express",
+    });
+
+    expect(runProjectSetupPrompts).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        ownerEmail: "owner@example.com",
+        authMode: "local",
+        adminMode: "none",
+        webTemplateId: "web-oauth",
+        apiTemplateId: "api-express",
+      },
+      undefined,
+      true,
+    );
+  });
+
+  it("rejects an email that is not an address", async () => {
+    await expect(
+      runCLI(undefined, [], { local: true, yes: true, email: "nope" }),
+    ).rejects.toThrow(/--email must be an email address/);
+  });
+
+  it.each([
+    ["auth", "podman", /Unknown value "podman" for --auth/],
+    ["admin", "sidecar", /Unknown value "sidecar" for --admin/],
+  ])("rejects an unknown --%s value", async (flag, value, expected) => {
+    await expect(
+      runCLI(undefined, [], { local: true, yes: true, [flag]: value }),
+    ).rejects.toThrow(expected);
+  });
+
+  it("rejects --web naming an api template", async () => {
+    await expect(
+      runCLI(undefined, [], { local: true, web: "api-express" }),
+    ).rejects.toThrow(/--web expects a web template/);
+  });
+
+  it("rejects --api disagreeing with a bare template flag", async () => {
+    await expect(
+      runCLI(undefined, ["express"], { local: true, api: "api-soon" }),
+    ).rejects.toThrow(/Unknown option "--api-soon"/);
+  });
+
+  it("rejects --web disagreeing with a bare template flag", async () => {
+    await expect(
+      runCLI(undefined, ["oauth"], { local: true, web: "web-basic" }),
+    ).rejects.toThrow(/Conflicting web template flags/);
+  });
+
+  // The alias and the id name the same template, so agreeing is not a conflict.
+  it("accepts --web repeating a bare template flag", async () => {
+    await expect(
+      runCLI(undefined, ["oauth"], { local: true, yes: true, web: "web-oauth" }),
+    ).resolves.toBeUndefined();
+  });
+
+  // Starter files overwrite anything with the same name, so a blanket "assume
+  // yes" is deliberately not enough to reach it.
+  it("refuses to scaffold into a non-empty directory without --force", async () => {
+    vi.mocked(fs.readdirSync).mockReturnValue(["src"] as never);
+
+    await expect(
+      runCLI(undefined, [], { local: true, yes: true }),
+    ).rejects.toThrow(/Re-run with --force/);
+    expect(chooseExistingDirectoryAction).not.toHaveBeenCalled();
+    expect(runProjectSetupPrompts).not.toHaveBeenCalled();
+  });
+
+  it("scaffolds into a non-empty directory with --force", async () => {
+    vi.mocked(fs.readdirSync).mockReturnValue(["src"] as never);
+
+    await runCLI(undefined, [], { local: true, yes: true, force: true });
+
+    expect(chooseExistingDirectoryAction).not.toHaveBeenCalled();
+    expect(runProjectSetupPrompts).toHaveBeenCalled();
+    expect(out()).toContain("--force");
+  });
+
+  it("refuses to choose between a managed application and a local stack", async () => {
+    vi.mocked(createPortalClient).mockResolvedValue({} as never);
+    vi.mocked(listApplications).mockResolvedValue([app()] as never);
+
+    await expect(runCLI(undefined, [], { yes: true })).rejects.toThrow(
+      /Pass --app <id> .* or --local/,
+    );
+    expect(chooseScaffoldTarget).not.toHaveBeenCalled();
+  });
+
+  it("refuses to silently fall back to local when the control plane is unreachable", async () => {
+    vi.mocked(createPortalClient).mockRejectedValue(new Error("boom"));
+
+    await expect(runCLI(undefined, [], { yes: true })).rejects.toThrow(
+      /--yes will not silently scaffold a local stack/,
+    );
+    expect(confirmLocalFallback).not.toHaveBeenCalled();
+    expect(runProjectSetupPrompts).not.toHaveBeenCalled();
+  });
+
+  it("still scaffolds local when there is no session at all", async () => {
+    vi.mocked(createPortalClient).mockRejectedValue(
+      new ReauthRequiredError("no session"),
+    );
+
+    await runCLI(undefined, [], { yes: true, email: "dev@example.com" });
+
+    expect(runProjectSetupPrompts).toHaveBeenCalled();
+  });
+
+  it("skips OAuth provider setup rather than prompting for secrets", async () => {
+    vi.mocked(createPortalClient).mockRejectedValue(
+      new ReauthRequiredError("no session"),
+    );
+    vi.mocked(openTemplateSource).mockResolvedValue(
+      makeSource({
+        "web-basic": {
+          id: "web-basic",
+          targetDir: "web",
+          setup: { oauth: true },
+        },
+      }) as never,
+    );
+
+    await runCLI(undefined, [], { yes: true, email: "dev@example.com" });
+
+    expect(runOAuthSetupPrompts).not.toHaveBeenCalled();
+    expect(out()).toContain("Skipping OAuth provider setup");
+  });
+
+  it("refuses to rotate an existing service token without --force", async () => {
+    vi.mocked(createPortalClient).mockResolvedValue({} as never);
+    vi.mocked(listApplications).mockResolvedValue([
+      app({ hasServiceToken: true }),
+    ] as never);
+    vi.mocked(selectApplication).mockResolvedValue(
+      app({ hasServiceToken: true }) as never,
+    );
+    vi.mocked(runManagedTemplatePrompts).mockResolvedValue({
+      webTemplateId: "web-basic",
+      apiTemplateId: "api-express",
+    } as never);
+
+    await expect(
+      runCLI(undefined, [], { yes: true, appId: "app-1" }),
+    ).rejects.toThrow(/Re-run with --force to rotate it anyway/);
+    expect(rotateServiceToken).not.toHaveBeenCalled();
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it("rotates an existing service token with --force", async () => {
+    vi.mocked(createPortalClient).mockResolvedValue({} as never);
+    vi.mocked(listApplications).mockResolvedValue([
+      app({ hasServiceToken: true }),
+    ] as never);
+    vi.mocked(selectApplication).mockResolvedValue(
+      app({ hasServiceToken: true }) as never,
+    );
+    vi.mocked(runManagedTemplatePrompts).mockResolvedValue({
+      webTemplateId: "web-basic",
+      apiTemplateId: "api-express",
+    } as never);
+    vi.mocked(rotateServiceToken).mockResolvedValue("token" as never);
+
+    await runCLI(undefined, [], { yes: true, force: true, appId: "app-1" });
+
+    expect(rotateServiceToken).toHaveBeenCalled();
+    expect(confirm).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -7,6 +7,9 @@ import kleur from "kleur";
 import {
   runProjectSetupPrompts,
   runManagedTemplatePrompts,
+  ADMIN_MODES,
+  AUTH_MODES,
+  type Preselect,
 } from "../prompts/projectSetup.js";
 import { generateAuthServer } from "../generators/auth/auth.js";
 import { generateDockerCompose } from "../generators/docker/docker.js";
@@ -31,6 +34,8 @@ import {
   chooseExistingDirectoryAction,
   chooseScaffoldTarget,
   confirmLocalFallback,
+  type ExistingDirectoryAction,
+  type ScaffoldTarget,
 } from "../prompts/initMode.js";
 import { CancelledError, orCancel } from "../core/cancel.js";
 import type { CollectedOAuthProvider } from "../core/oauthProviders.js";
@@ -63,6 +68,18 @@ export interface InitOptions {
   profileFlag?: string;
   appId?: string;
   local?: boolean;
+  // --web / --api, the long form of the template flags. Resolved against the
+  // registry alongside them, and rejected when they name the wrong layer.
+  web?: string;
+  api?: string;
+  email?: string;
+  auth?: string;
+  admin?: string;
+  // --yes: answer every remaining question with the recommended option rather
+  // than prompting. It never stands in for a destructive confirmation; those
+  // take --force.
+  yes?: boolean;
+  force?: boolean;
 }
 
 export async function runCLI(
@@ -85,15 +102,18 @@ export async function runCLI(
 
   const openSource = lazyTemplateSource();
 
-  // Template flags are resolved against the registry before a directory is
-  // created and before the overwrite confirmation runs, so an unknown or
-  // conflicting flag can never reach a destructive prompt on its way to an
-  // error. Skipped entirely when there are no flags, which keeps the
-  // integrate-an-existing-project path from fetching a registry it never reads.
-  let preselect: TemplatePreselect = {};
-  if (aliases.length > 0) {
+  // Every flag is validated against the registry and the known values before a
+  // directory is created and before the overwrite confirmation runs, so a bad
+  // flag can never reach a destructive prompt on its way to an error. The
+  // registry is only fetched when a template flag needs resolving, which keeps
+  // the integrate-an-existing-project path from paying for one it never reads.
+  const answers = resolveAnswerFlags(opts);
+  if (aliases.length > 0 || opts.web || opts.api) {
     const { registry } = await openSource();
-    preselect = resolveTemplateAliases(aliases, registry.templates);
+    Object.assign(
+      answers,
+      resolveTemplateSelection(aliases, opts, registry.templates),
+    );
   }
 
   let root = cwd;
@@ -123,7 +143,7 @@ export async function runCLI(
   if (created) process.on("SIGINT", onInterrupt);
 
   try {
-    await scaffold(root, projectName, preselect, openSource, opts);
+    await scaffold(root, projectName, answers, openSource, opts);
   } catch (err) {
     // Anything short of a completed scaffold leaves nothing behind, so a retry
     // is not blocked by "Directory already exists" from a half-built attempt.
@@ -157,7 +177,7 @@ function discard(dir: string | null): void {
 async function scaffold(
   root: string,
   projectName: string | undefined,
-  preselect: TemplatePreselect,
+  preselect: Preselect,
   openSource: OpenSource,
   opts: InitOptions,
 ) {
@@ -192,7 +212,7 @@ async function scaffold(
     // --app is explicit managed intent, so it skips the question and integrates.
     const action = opts.appId
       ? "integrate"
-      : await chooseExistingDirectoryAction(canConnect);
+      : await resolveExistingDirectoryAction(canConnect, opts);
     if (action === "integrate") {
       await integrateExistingProject(root, client!, apps, opts);
       return;
@@ -202,7 +222,7 @@ async function scaffold(
   if (canConnect) {
     const target = opts.appId
       ? "managed"
-      : await chooseScaffoldTarget(apps.length);
+      : await resolveScaffoldTarget(apps.length, opts);
     if (target === "managed") {
       await scaffoldManaged(
         root,
@@ -218,6 +238,13 @@ async function scaffold(
   } else if (client) {
     console.log(kleur.yellow(noConnectableMessage(allApps.length > 0)));
   } else if (fallbackReason === "unreachable") {
+    // Falling back to local changes where the project's auth lives, so --yes
+    // does not get to make that call on its own; --local says it outright.
+    if (opts.yes) {
+      throw new Error(
+        "Could not reach the Seamless control plane, and --yes will not silently scaffold a local stack instead. Re-run with --local to scaffold self-hosted.",
+      );
+    }
     await confirmLocalFallback();
   } else if (fallbackReason === "no-session") {
     console.log(
@@ -227,7 +254,42 @@ async function scaffold(
     );
   }
 
-  await scaffoldLocal(root, projectName, preselect, openSource);
+  await scaffoldLocal(root, projectName, preselect, openSource, opts);
+}
+
+// Writing starter files over a directory someone already has work in is the one
+// destructive step in a scaffold, so --yes is deliberately not enough to reach
+// it. --force is, and it says nothing about the integrate-or-scaffold question,
+// which --app answers instead.
+async function resolveExistingDirectoryAction(
+  canConnect: boolean,
+  opts: InitOptions,
+): Promise<ExistingDirectoryAction> {
+  if (!opts.yes) return chooseExistingDirectoryAction(canConnect);
+
+  if (!opts.force) {
+    throw new Error(
+      "This directory is not empty, and starter files overwrite anything with the same name. Re-run with --force to scaffold here anyway, or with --app <id> to connect the existing project to a managed application.",
+    );
+  }
+
+  console.log(
+    kleur.yellow("Scaffolding into a directory that is not empty (--force)."),
+  );
+  return "scaffold";
+}
+
+// Managed or local decides where the project's auth lives for good, so --yes
+// alone will not pick: --app <id> means managed and --local means self-hosted.
+async function resolveScaffoldTarget(
+  appCount: number,
+  opts: InitOptions,
+): Promise<ScaffoldTarget> {
+  if (!opts.yes) return chooseScaffoldTarget(appCount);
+
+  throw new Error(
+    "You are logged in, so --yes will not guess between a managed application and a local stack. Pass --app <id> to connect one of your managed applications, or --local to scaffold a self-hosted stack.",
+  );
 }
 
 // The bundled database as a connection string with placeholder credentials, or
@@ -293,6 +355,7 @@ async function scaffoldManaged(
   const answers = await runManagedTemplatePrompts(
     source.registry.templates,
     preselect,
+    opts.yes,
   );
 
   const selected = await resolveSelectedTemplates(
@@ -319,7 +382,7 @@ async function scaffoldManaged(
   // reporting it against a half-wired project.
   const databaseUrl = await resolveDatabaseUrl(client, app);
 
-  const serviceToken = await issueServiceToken(client, app);
+  const serviceToken = await issueServiceToken(client, app, opts);
 
   const authServerUrl = normalizeInstanceUrl(app.domain);
 
@@ -380,14 +443,16 @@ async function scaffoldManaged(
 async function scaffoldLocal(
   root: string,
   projectName: string | undefined,
-  preselect: TemplatePreselect,
+  preselect: Preselect,
   openSource: OpenSource,
+  opts: InitOptions,
 ) {
   const source = await openSource();
   const answers = await runProjectSetupPrompts(
     source.registry.templates,
     preselect,
     getPortalSession()?.email,
+    opts.yes,
   );
 
   const selected = await resolveSelectedTemplates(
@@ -399,10 +464,20 @@ async function scaffoldLocal(
 
   // Templates can opt into OAuth setup (manifest setup.oauth). Collect providers now,
   // before scaffolding, so the auth server can be wired up with them below.
+  // Provider credentials are per-provider secrets with no flag form, so --yes
+  // scaffolds the starter with none configured rather than asking.
   const webSelection = selected.find((s) => s.entry.kind === "web");
   let oauthProviders: CollectedOAuthProvider[] = [];
   if (webSelection?.manifest.setup?.oauth) {
-    oauthProviders = await runOAuthSetupPrompts();
+    if (opts.yes) {
+      console.log(
+        kleur.yellow(
+          "Skipping OAuth provider setup (--yes). Add providers later with `seamless config oauth-providers add`.",
+        ),
+      );
+    } else {
+      oauthProviders = await runOAuthSetupPrompts();
+    }
   }
 
   for (const { entry, dir } of selected) {
@@ -492,7 +567,7 @@ async function integrateExistingProject(
   // reporting it against a half-wired project.
   const databaseUrl = await resolveDatabaseUrl(client, app);
 
-  const serviceToken = await issueServiceToken(client, app);
+  const serviceToken = await issueServiceToken(client, app, opts);
 
   const authServerUrl = normalizeInstanceUrl(app.domain);
   const apiDir = path.join(root, "api");
@@ -575,16 +650,33 @@ function printManagedValues(authServerUrl: string, serviceToken: string) {
 async function issueServiceToken(
   client: AuthClient,
   app: PortalApp,
+  opts: InitOptions,
 ): Promise<string> {
   if (app.hasServiceToken) {
-    const proceed = orCancel(
-      await confirm({
-        message: `"${app.name}" already has a service token. Issuing a new one invalidates the existing token. Continue?`,
-        initialValue: false,
-      }),
-    );
-    if (!proceed) {
-      throw new CancelledError("Cancelled. No token was issued.");
+    // Rotation breaks whatever is running on the old token, so it is a
+    // destructive confirmation like the overwrite one: --yes does not answer it,
+    // --force does.
+    if (opts.yes) {
+      if (!opts.force) {
+        throw new Error(
+          `"${app.name}" already has a service token, and issuing a new one invalidates it (breaking anything already deployed with it). Re-run with --force to rotate it anyway.`,
+        );
+      }
+      console.log(
+        kleur.yellow(
+          `Rotating the existing service token for "${app.name}" (--force).`,
+        ),
+      );
+    } else {
+      const proceed = orCancel(
+        await confirm({
+          message: `"${app.name}" already has a service token. Issuing a new one invalidates the existing token. Continue?`,
+          initialValue: false,
+        }),
+      );
+      if (!proceed) {
+        throw new CancelledError("Cancelled. No token was issued.");
+      }
     }
   }
   return rotateServiceToken(client, app.id);
@@ -663,6 +755,83 @@ function printOAuthNextSteps(providers: CollectedOAuthProvider[]) {
 export interface TemplatePreselect {
   webTemplateId?: string;
   apiTemplateId?: string;
+}
+
+// The non-template answers a flag can supply. Validated here so an unusable
+// value is reported before anything is created, and so the prompts only ever
+// see a value they would have accepted themselves.
+function resolveAnswerFlags(opts: InitOptions): Preselect {
+  const answers: Preselect = {};
+
+  if (opts.email !== undefined) {
+    if (!opts.email.includes("@")) {
+      throw new Error(`--email must be an email address, got "${opts.email}".`);
+    }
+    answers.ownerEmail = opts.email;
+  }
+
+  if (opts.auth !== undefined) {
+    answers.authMode = oneOf(opts.auth, AUTH_MODES, "--auth");
+  }
+
+  if (opts.admin !== undefined) {
+    answers.adminMode = oneOf(opts.admin, ADMIN_MODES, "--admin");
+  }
+
+  return answers;
+}
+
+function oneOf<T extends string>(value: string, allowed: T[], flag: string): T {
+  if (!(allowed as string[]).includes(value)) {
+    throw new Error(
+      `Unknown value "${value}" for ${flag}. Expected one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value as T;
+}
+
+// Combines the template flags: the bare `--<id>` / `--<alias>` form, which infers
+// the layer from the registry, and the explicit `--web=` / `--api=` form, which
+// names it. Both accept either spelling, and disagreeing about a layer is an
+// error rather than a silent last-one-wins.
+function resolveTemplateSelection(
+  aliases: string[],
+  opts: InitOptions,
+  templates: RegistryEntry[],
+): TemplatePreselect {
+  const preselect = resolveTemplateAliases(aliases, templates);
+
+  for (const [flag, kind] of [
+    ["web", "web"],
+    ["api", "api"],
+  ] as const) {
+    const value = opts[flag];
+    if (!value) continue;
+
+    const named = value.replace(/^--+/, "");
+    const { webTemplateId, apiTemplateId } = resolveTemplateAliases(
+      [named],
+      templates,
+    );
+    const id = kind === "web" ? webTemplateId : apiTemplateId;
+    if (!id) {
+      throw new Error(
+        `--${flag} expects a ${kind} template, but "${value}" is not one. Run \`seamless templates list\` to see which templates are ${kind}.`,
+      );
+    }
+
+    const existing = kind === "web" ? preselect.webTemplateId : preselect.apiTemplateId;
+    if (existing && existing !== id) {
+      throw new Error(
+        `Conflicting ${kind} template flags: --${flag}=${value} cannot combine with --${existing}.`,
+      );
+    }
+
+    if (kind === "web") preselect.webTemplateId = id;
+    else preselect.apiTemplateId = id;
+  }
+
+  return preselect;
 }
 
 // Resolves `--<alias>` and `--<id>` flags (e.g. --oauth, --react-oauth) to specific

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -132,11 +132,56 @@ describe("index dispatcher", () => {
   it("dispatches init with parsed project name, aliases, profile and app flags", async () => {
     await dispatch(["init", "my-app", "--local", "--oauth", "--profile", "prod", "--app", "app1"]);
     const { runCLI } = await import("./commands/init.js");
-    expect(runCLI).toHaveBeenCalledWith("my-app", ["oauth"], {
-      profileFlag: "prod",
-      appId: "app1",
-      local: true,
-    });
+    expect(runCLI).toHaveBeenCalledWith(
+      "my-app",
+      ["oauth"],
+      expect.objectContaining({
+        profileFlag: "prod",
+        appId: "app1",
+        local: true,
+      }),
+    );
+  });
+
+  it("dispatches init with the answer flags", async () => {
+    await dispatch([
+      "init",
+      "my-app",
+      "--yes",
+      "--force",
+      "--web=react-oauth",
+      "--api",
+      "fastify",
+      "--email=dev@example.com",
+      "--auth=docker",
+      "--admin=none",
+    ]);
+    const { runCLI } = await import("./commands/init.js");
+    expect(runCLI).toHaveBeenCalledWith(
+      "my-app",
+      [],
+      expect.objectContaining({
+        yes: true,
+        force: true,
+        web: "react-oauth",
+        api: "fastify",
+        email: "dev@example.com",
+        auth: "docker",
+        admin: "none",
+      }),
+    );
+  });
+
+  // -y is a switch, not a project name, and the answer flags must not be
+  // mistaken for template ids.
+  it("keeps init switches out of the template aliases and the project name", async () => {
+    await dispatch(["init", "-y", "--local", "--force", "--basic"]);
+    const { runCLI } = await import("./commands/init.js");
+    expect(runCLI).toHaveBeenCalledWith(
+      undefined,
+      ["basic"],
+      expect.objectContaining({ yes: true, local: true, force: true }),
+    );
   });
 
   it("dispatches check", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { runCLI } from "./commands/init.js";
+import { runCLI, type InitOptions } from "./commands/init.js";
 import { extractFlag, hasHelpFlag } from "./core/args.js";
 import { runCheck } from "./commands/check.js";
 import { printCommandHelp, printHelp } from "./commands/help.js";
@@ -61,21 +61,7 @@ async function main() {
   }
 
   if (command === "init") {
-    const profileFlag = extractFlag(args.slice(1), "profile");
-    const appFlag = extractFlag(profileFlag.rest, "app");
-    const rest = appFlag.rest;
-
-    const local = rest.includes("--local");
-    const aliases = rest
-      .filter((a) => a.startsWith("--") && a !== "--local")
-      .map((a) => a.replace(/^--+/, ""));
-    const projectName = rest.find((a) => !a.startsWith("--"));
-
-    await runCLI(projectName, aliases, {
-      profileFlag: profileFlag.value,
-      appId: appFlag.value,
-      local,
-    });
+    await runCLI(...parseInitArgs(args.slice(1)));
     return;
   }
 
@@ -140,6 +126,50 @@ async function main() {
   }
 
   unknownCommand(command);
+}
+
+// Flags init handles itself rather than passing through as a template flag.
+// Anything else starting with `--` is a template id or alias, which is what
+// keeps adding a template to the registry from needing code here.
+const INIT_SWITCHES = new Set(["--local", "--yes", "-y", "--force"]);
+
+// init's arguments, as the runCLI(projectName, aliases, opts) triple. Only
+// splits them up: which values are valid is settled in init.ts, against the
+// registry, before anything is written.
+export function parseInitArgs(
+  args: string[],
+): [string | undefined, string[], InitOptions] {
+  const valued = ["profile", "app", "web", "api", "email", "auth", "admin"];
+  const values: Record<string, string | undefined> = {};
+
+  let rest = args;
+  for (const name of valued) {
+    const extracted = extractFlag(rest, name);
+    values[name] = extracted.value;
+    rest = extracted.rest;
+  }
+
+  const aliases = rest
+    .filter((a) => a.startsWith("--") && !INIT_SWITCHES.has(a))
+    .map((a) => a.replace(/^--+/, ""));
+  const projectName = rest.find((a) => !a.startsWith("-"));
+
+  return [
+    projectName,
+    aliases,
+    {
+      profileFlag: values.profile,
+      appId: values.app,
+      web: values.web,
+      api: values.api,
+      email: values.email,
+      auth: values.auth,
+      admin: values.admin,
+      local: rest.includes("--local"),
+      yes: rest.includes("--yes") || rest.includes("-y"),
+      force: rest.includes("--force"),
+    },
+  ];
 }
 
 // An unrecognized command used to be treated as a project name and scaffolded,

--- a/src/prompts/projectSetup.test.ts
+++ b/src/prompts/projectSetup.test.ts
@@ -279,3 +279,109 @@ describe("runProjectSetupPrompts", () => {
     expect(out()).toContain("Enabling automatically");
   });
 });
+
+describe("runProjectSetupPrompts with --yes", () => {
+  it("answers every question with the recommended option", async () => {
+    const result = await runProjectSetupPrompts(
+      fullRegistry(),
+      { ownerEmail: "owner@example.com" },
+      undefined,
+      true,
+    );
+
+    expect(result).toEqual({
+      web: true,
+      // The first selectable template of each kind, which is what a developer
+      // pressing Enter through the prompts would land on.
+      webTemplateId: "web-a",
+      api: true,
+      apiTemplateId: "api-a",
+      authMode: "docker",
+      useDocker: true,
+      adminMode: "api",
+      ownerEmail: "owner@example.com",
+    });
+    expect(select).not.toHaveBeenCalled();
+    expect(confirm).not.toHaveBeenCalled();
+    expect(text).not.toHaveBeenCalled();
+  });
+
+  it("echoes what it chose so an unattended run still reports the stack", async () => {
+    await runProjectSetupPrompts(
+      fullRegistry(),
+      { ownerEmail: "owner@example.com" },
+      undefined,
+      true,
+    );
+
+    expect(out()).toContain("Web example: React");
+    expect(out()).toContain("Backend: Express");
+    expect(out()).toContain("Owner email: owner@example.com");
+    expect(out()).toContain("Auth server: docker");
+    expect(out()).toContain("Admin console: api");
+  });
+
+  it("prefers supplied answers over the recommended options", async () => {
+    const result = await runProjectSetupPrompts(
+      fullRegistry(),
+      {
+        webTemplateId: "web-b",
+        apiTemplateId: "api-a",
+        ownerEmail: "owner@example.com",
+        authMode: "local",
+        adminMode: "none",
+      },
+      undefined,
+      true,
+    );
+
+    expect(result).toMatchObject({
+      webTemplateId: "web-b",
+      authMode: "local",
+      adminMode: "none",
+    });
+    // The Docker-is-required confirmation is a prompt, not a question --yes has
+    // an answer for; useDocker is true either way.
+    expect(confirm).not.toHaveBeenCalled();
+    expect(result.useDocker).toBe(true);
+  });
+
+  it("falls back to the portal session email", async () => {
+    const result = await runProjectSetupPrompts(
+      fullRegistry(),
+      {},
+      "session@example.com",
+      true,
+    );
+
+    expect(result.ownerEmail).toBe("session@example.com");
+  });
+
+  it("refuses to guess an owner email", async () => {
+    await expect(
+      runProjectSetupPrompts(fullRegistry(), {}, undefined, true),
+    ).rejects.toThrow(/--yes needs an owner email/);
+  });
+
+  it("refuses when no template of a kind is selectable", async () => {
+    const noSelectableWeb = fullRegistry().filter(
+      (t) => t.kind === "api" || t.status === "coming-soon",
+    );
+
+    await expect(
+      runProjectSetupPrompts(
+        noSelectableWeb,
+        { ownerEmail: "owner@example.com" },
+        undefined,
+        true,
+      ),
+    ).rejects.toThrow(/no selectable web templates/);
+  });
+
+  it("answers the managed template questions too", async () => {
+    const result = await runManagedTemplatePrompts(fullRegistry(), {}, true);
+
+    expect(result).toEqual({ webTemplateId: "web-a", apiTemplateId: "api-a" });
+    expect(select).not.toHaveBeenCalled();
+  });
+});

--- a/src/prompts/projectSetup.ts
+++ b/src/prompts/projectSetup.ts
@@ -4,8 +4,17 @@ import { orCancel } from "../core/cancel.js";
 
 import type { RegistryEntry, TemplateKind } from "../core/templates.js";
 
-type AuthMode = "local" | "docker";
-type AdminMode = "api" | "image" | "source" | "none";
+export type AuthMode = "local" | "docker";
+export type AdminMode = "api" | "image" | "source" | "none";
+
+export const AUTH_MODES: AuthMode[] = ["docker", "local"];
+export const ADMIN_MODES: AdminMode[] = ["api", "image", "source", "none"];
+
+// What each question falls back to when --yes answers it. These match the
+// options labelled "(recommended)" in the prompts below, so an unattended run
+// gets the same stack a developer pressing Enter would.
+const DEFAULT_AUTH_MODE: AuthMode = "docker";
+const DEFAULT_ADMIN_MODE: AdminMode = "api";
 
 interface Option {
   value: string;
@@ -33,13 +42,57 @@ function toOptions(templates: RegistryEntry[], kind: TemplateKind): Option[] {
   }));
 }
 
-interface Preselect {
+// The registry lists templates in the order the prompt shows them, so the first
+// selectable one of a kind is what a developer pressing Enter would land on.
+function defaultTemplateId(
+  templates: RegistryEntry[],
+  kind: TemplateKind,
+): string {
+  const entry = templates.find(
+    (t) => t.kind === kind && t.status !== "coming-soon",
+  );
+  if (!entry) {
+    throw new Error(
+      `The template registry has no selectable ${kind} templates, so --yes has nothing to choose. Run \`seamless templates list\` to see what is available.`,
+    );
+  }
+  return entry.id;
+}
+
+// Answers supplied on the command line. Any field set here replaces its prompt;
+// under assumeYes the rest fall back to the recommended option, except
+// ownerEmail, which has no safe default and is required instead.
+export interface Preselect {
   webTemplateId?: string;
   apiTemplateId?: string;
+  ownerEmail?: string;
+  authMode?: AuthMode;
+  adminMode?: AdminMode;
 }
 
 function labelFor(templates: RegistryEntry[], id: string): string {
   return templates.find((t) => t.id === id)?.label ?? id;
+}
+
+async function resolveTemplateId(
+  templates: RegistryEntry[],
+  kind: TemplateKind,
+  preselected: string | undefined,
+  message: string,
+  echoLabel: string,
+  assumeYes: boolean,
+): Promise<string> {
+  const chosen =
+    preselected ?? (assumeYes ? defaultTemplateId(templates, kind) : undefined);
+
+  if (chosen) {
+    console.log(`${echoLabel}: ${labelFor(templates, chosen)}`);
+    return chosen;
+  }
+
+  return orCancel(
+    await select({ message, options: toOptions(templates, kind) }),
+  ) as string;
 }
 
 // Managed connect only needs the web and api templates: the auth server is the
@@ -48,30 +101,24 @@ function labelFor(templates: RegistryEntry[], id: string): string {
 export async function runManagedTemplatePrompts(
   templates: RegistryEntry[],
   preselect: Preselect = {},
+  assumeYes = false,
 ) {
-  let webTemplateId = preselect.webTemplateId;
-  if (webTemplateId) {
-    console.log(`Web example: ${labelFor(templates, webTemplateId)}`);
-  } else {
-    webTemplateId = orCancel(
-      await select({
-        message: "Web example",
-        options: toOptions(templates, "web"),
-      }),
-    ) as string;
-  }
-
-  let apiTemplateId = preselect.apiTemplateId;
-  if (apiTemplateId) {
-    console.log(`Backend: ${labelFor(templates, apiTemplateId)}`);
-  } else {
-    apiTemplateId = orCancel(
-      await select({
-        message: "Backend framework",
-        options: toOptions(templates, "api"),
-      }),
-    ) as string;
-  }
+  const webTemplateId = await resolveTemplateId(
+    templates,
+    "web",
+    preselect.webTemplateId,
+    "Web example",
+    "Web example",
+    assumeYes,
+  );
+  const apiTemplateId = await resolveTemplateId(
+    templates,
+    "api",
+    preselect.apiTemplateId,
+    "Backend framework",
+    "Backend",
+    assumeYes,
+  );
 
   return { webTemplateId, apiTemplateId };
 }
@@ -80,86 +127,90 @@ export async function runProjectSetupPrompts(
   templates: RegistryEntry[],
   preselect: Preselect = {},
   knownEmail?: string,
+  assumeYes = false,
 ) {
-  let webTemplateId = preselect.webTemplateId;
-  if (webTemplateId) {
-    console.log(`Web example: ${labelFor(templates, webTemplateId)}`);
-  } else {
-    webTemplateId = orCancel(
-      await select({
-        message: "Web example",
-        options: toOptions(templates, "web"),
-      }),
-    ) as string;
-  }
-
-  let apiTemplateId = preselect.apiTemplateId;
-  if (apiTemplateId) {
-    console.log(`Backend: ${labelFor(templates, apiTemplateId)}`);
-  } else {
-    apiTemplateId = orCancel(
-      await select({
-        message: "Backend framework",
-        options: toOptions(templates, "api"),
-      }),
-    ) as string;
-  }
+  const webTemplateId = await resolveTemplateId(
+    templates,
+    "web",
+    preselect.webTemplateId,
+    "Web example",
+    "Web example",
+    assumeYes,
+  );
+  const apiTemplateId = await resolveTemplateId(
+    templates,
+    "api",
+    preselect.apiTemplateId,
+    "Backend framework",
+    "Backend",
+    assumeYes,
+  );
 
   // Written to the auth server as OWNER_EMAIL, which grants the admin role to
   // this address at signup. Asking here means registering in the scaffolded app
-  // is the only step between `docker compose up` and a working admin.
-  const ownerEmail = orCancel(
-    await text({
-      message: "Your email (becomes the admin when you register)",
-      placeholder: knownEmail ?? "you@example.com",
-      initialValue: knownEmail ?? "",
-      validate: (value) =>
-        (value ?? "").includes("@") ? undefined : "Enter a valid email address",
-    }),
-  ) as string;
+  // is the only step between `docker compose up` and a working admin. There is
+  // no sane default for it, so --yes takes it from the flag or the portal
+  // session and otherwise refuses to guess.
+  const ownerEmail = await resolveOwnerEmail(
+    preselect.ownerEmail ?? (assumeYes ? knownEmail : undefined),
+    knownEmail,
+    assumeYes,
+  );
 
-  const authMode = orCancel(
-    await select({
-      message: "How would you like to run SeamlessAuth?",
-      options: [
-        {
-          value: "docker",
-          label: "Docker container (recommended)",
-        },
-        {
-          value: "local",
-          label: "Local dev server (advanced)",
-        },
-      ],
-    }),
-  ) as AuthMode;
+  const authMode = await resolveChoice<AuthMode>(
+    preselect.authMode,
+    assumeYes ? DEFAULT_AUTH_MODE : undefined,
+    "Auth server",
+    async () =>
+      orCancel(
+        await select({
+          message: "How would you like to run SeamlessAuth?",
+          options: [
+            {
+              value: "docker",
+              label: "Docker container (recommended)",
+            },
+            {
+              value: "local",
+              label: "Local dev server (advanced)",
+            },
+          ],
+        }),
+      ) as AuthMode,
+  );
 
-  const adminMode = orCancel(
-    await select({
-      message: "How would you like to host the admin console?",
-      options: [
-        {
-          value: "api",
-          label: "Served by your API at /console (recommended)",
-        },
-        {
-          value: "image",
-          label: "Separate container — official Docker image",
-        },
-        {
-          value: "source",
-          label: "Separate container — clone repo for modification",
-        },
-        {
-          value: "none",
-          label: "Don't include the admin console",
-        },
-      ],
-      initialValue: "api",
-    }),
-  ) as AdminMode;
+  const adminMode = await resolveChoice<AdminMode>(
+    preselect.adminMode,
+    assumeYes ? DEFAULT_ADMIN_MODE : undefined,
+    "Admin console",
+    async () =>
+      orCancel(
+        await select({
+          message: "How would you like to host the admin console?",
+          options: [
+            {
+              value: "api",
+              label: "Served by your API at /console (recommended)",
+            },
+            {
+              value: "image",
+              label: "Separate container — official Docker image",
+            },
+            {
+              value: "source",
+              label: "Separate container — clone repo for modification",
+            },
+            {
+              value: "none",
+              label: "Don't include the admin console",
+            },
+          ],
+          initialValue: "api",
+        }),
+      ) as AdminMode,
+  );
 
-  if (authMode === "local") {
+  if (authMode === "local" && !assumeYes) {
     const confirmDocker = orCancel(
       await confirm({
         message:
@@ -188,4 +239,48 @@ export async function runProjectSetupPrompts(
     adminMode,
     ownerEmail: ownerEmail.trim(),
   };
+}
+
+// A flag answers the question outright; --yes falls back to the recommended
+// option. Either way the choice is echoed, so an unattended run still reports
+// what it picked.
+async function resolveChoice<T extends string>(
+  supplied: T | undefined,
+  fallback: T | undefined,
+  echoLabel: string,
+  ask: () => Promise<T>,
+): Promise<T> {
+  const chosen = supplied ?? fallback;
+  if (chosen) {
+    console.log(`${echoLabel}: ${chosen}`);
+    return chosen;
+  }
+  return ask();
+}
+
+async function resolveOwnerEmail(
+  supplied: string | undefined,
+  knownEmail: string | undefined,
+  assumeYes: boolean,
+): Promise<string> {
+  if (supplied) {
+    console.log(`Owner email: ${supplied}`);
+    return supplied;
+  }
+
+  if (assumeYes) {
+    throw new Error(
+      "--yes needs an owner email, which becomes the admin when you register. Pass --email <address>, or run `seamless login` so it can be taken from your portal session.",
+    );
+  }
+
+  return orCancel(
+    await text({
+      message: "Your email (becomes the admin when you register)",
+      placeholder: knownEmail ?? "you@example.com",
+      initialValue: knownEmail ?? "",
+      validate: (value) =>
+        (value ?? "").includes("@") ? undefined : "Enter a valid email address",
+    }),
+  ) as string;
 }


### PR DESCRIPTION
Closes #152. Part of #154. Stacked on #155, review that first (this PR's diff is only its own commit).

The core item on the feedback list: `init` had no flag form for email, auth mode, or admin mode, so it could not run from CI, a Dockerfile, or a script without allocating a pty. The workaround was an `expect` script, which required knowing the prompt order, which required reading the source.

```bash
seamless init my-app --local --yes --email=you@example.com
```

## Flags

`--yes` (`-y`) answers every remaining question with the option its prompt marks `(recommended)`. Each question also gets its own flag, honored with or without `--yes`:

| Flag | Question | Default under `--yes` |
| --- | --- | --- |
| `--web=<id\|alias>` | Web example | first selectable web template |
| `--api=<id\|alias>` | Backend framework | first selectable api template |
| `--email=<address>` | Owner email (becomes the admin) | required |
| `--auth=<docker\|local>` | How the auth server runs | `docker` |
| `--admin=<api\|image\|source\|none>` | Where the console is hosted | `api` |

The template defaults come from registry order rather than a hardcoded id, so they stay a registry concern. Values are validated in `runCLI` (against the registry for `--web`/`--api`, against the mode lists for `--auth`/`--admin`) before a directory is created, so a bad value never leaves a husk behind.

## What `--yes` will not decide

Three things it stops on instead of guessing:

- **Managed or local**, with a portal session and neither `--local` nor `--app <id>`. That decides where the project's auth lives for good.
- **Scaffolding into a non-empty directory.** Starter files overwrite anything with the same name; that takes `--force`. The comment in `initMode.ts` already said the option hint is not consent, and a blanket "assume yes" is not either.
- **Rotating an application's existing service token**, which invalidates the old one and breaks whatever is deployed on it. Also `--force`.

A template that would prompt for OAuth provider credentials is scaffolded with none configured (there is no flag form for a per-provider secret) and says so.

## Parsing

`init`'s argument handling moves out of the dispatcher into `parseInitArgs`. The old code treated every `--` argument that was not `--local` as a template alias, so any new switch would have been read as a template name.

## Checks

`npm run build` and `npm test` pass (781 passed, 4 skipped). Smoke-tested end to end with stdin closed: a full scaffold with no prompts, plus each guard rail (missing `--email`, non-empty directory without `--force`, bad `--admin` value) failing with the right message and leaving nothing on disk.