### PR TITLE
chore: scaffold and verify on PostgreSQL 18

### DIFF
--- a/.changeset/postgres-18.md
+++ b/.changeset/postgres-18.md
@@ -1,0 +1,16 @@
+---
+"seamless-cli": minor
+---
+
+Scaffold new projects on PostgreSQL 18, and run the conformance harness on it too.
+
+`seamless init` generated a stack pinned to `postgres:17` while the verify harness ran `postgres:16`.
+Both are now `postgres:18`, so what the harness certifies is the major a fresh scaffold actually
+gets.
+
+This does not touch an existing project. The image is written into each scaffold's own
+`docker-compose.yml` at generation time, so a project keeps whatever major it was scaffolded with and
+its data directory is never pulled out from under it. Only newly scaffolded projects get 18, on a
+fresh volume. Upgrading an existing project is a deliberate act: change the image in its
+`docker-compose.yml`, and dump and restore the volume, since PostgreSQL will not start against a data
+directory written by a different major.

--- a/src/core/images.test.ts
+++ b/src/core/images.test.ts
@@ -11,7 +11,7 @@ import {
 
 describe("image and version constants", () => {
   it("pins the postgres image", () => {
-    expect(POSTGRES_IMAGE).toBe("postgres:17");
+    expect(POSTGRES_IMAGE).toBe("postgres:18");
   });
 
   it("builds the auth API image tag from its version", () => {

--- a/src/core/images.ts
+++ b/src/core/images.ts
@@ -1,4 +1,7 @@
-export const POSTGRES_IMAGE = "postgres:17";
+// Baked into each scaffold's own docker-compose.yml at generation time, so a
+// bump here reaches new projects only. An existing project keeps the major it was
+// scaffolded with, and never has its data directory pulled out from under it.
+export const POSTGRES_IMAGE = "postgres:18";
 
 export const SEAMLESS_AUTH_API_VERSION = "v0.7.1";
 

--- a/verify/docker-compose.verify.yml
+++ b/verify/docker-compose.verify.yml
@@ -15,7 +15,10 @@ name: seamless-verify
 
 services:
   postgres:
-    image: postgres:16
+    # Matches POSTGRES_IMAGE in src/core/images.ts, so the harness runs the same
+    # major a fresh scaffold gets. Every run starts with `down -v`, so the volume
+    # is always new and a major bump needs no migration here.
+    image: postgres:18
     environment:
       POSTGRES_USER: seamless
       POSTGRES_PASSWORD: seamless


### PR DESCRIPTION
Follow-up to the version audit on #146, where I flagged `postgres:17` as a major behind and said it wanted its own PR.

## The drift

Two pins had come apart:

| Where | Was | Now |
| --- | --- | --- |
| `src/core/images.ts` (what `init` scaffolds) | `postgres:17` | `postgres:18` |
| `verify/docker-compose.verify.yml` (the harness) | `postgres:16` | `postgres:18` |

The harness was certifying a different major than a fresh scaffold actually got, which is the part worth fixing regardless of which version wins.

## Blast radius, corrected

I was more alarmist about this on #146 than it deserved. I said it "breaks the data directory for anyone with an existing volume" — that is wrong for this repo, and I checked before writing the bump:

- `POSTGRES_IMAGE` is interpolated into each scaffold's own `docker-compose.yml` at generation time (`src/generators/docker/docker.ts`). An existing project keeps the major it was scaffolded with; nothing reaches back and changes it.
- The harness runs `compose down -v` at the start of every run, so its volume is always fresh.

So this reaches new scaffolds on a new volume, and nothing else. Upgrading an existing project stays a deliberate act (change the image, dump and restore), and the changeset says so.

## Checks

`npm run build` and `npm test` pass (815 passed, 4 skipped). Scaffolded a project from the built CLI and confirmed its generated compose says `image: postgres:18`. Smoke-tested the image itself: `PostgreSQL 18.4 (Debian 18.4-1.pgdg13+1)` starts and answers queries.

The `verify / verify` CI job is the real test here, since it stands the whole stack up on 18. I did not run it locally this time because the ports were in use.

## Not in this PR

The org has other postgres pins, inventoried in a comment below. They are separate repos with separate risk (several have long-lived local dev volumes, and the Aurora pins are production), so they want their own PRs rather than being swept in here.