### PR TITLE
fix: mount the scaffolded database volume where PostgreSQL 18 stores data

### DIFF
--- a/.changeset/postgres-18-volume-mount.md
+++ b/.changeset/postgres-18-volume-mount.md
@@ -1,0 +1,22 @@
+---
+"seamless-cli": patch
+---
+
+Fix the scaffolded database failing to start on PostgreSQL 18.
+
+The PostgreSQL 18 bump moved the image tag but not the volume mount. PostgreSQL 18+ images store data
+in a major-versioned subdirectory (`/var/lib/postgresql/18/docker`), so a mount at
+`/var/lib/postgresql/data` is ignored and the container refuses to start, restart-looping on:
+
+```
+Error: in 18+, these Docker images are configured to store database data in a
+       format which is compatible with "pg_ctlcluster" ...
+       Counter to that, there appears to be PostgreSQL data in:
+         /var/lib/postgresql/data (unused mount/volume)
+```
+
+The generated `docker-compose.yml` now mounts `pgdata:/var/lib/postgresql`. See
+docker-library/postgres#1259.
+
+This only ever affected projects scaffolded from the unreleased PostgreSQL 18 change, so no published
+version of the CLI produced a broken scaffold.

--- a/src/generators/docker/docker.test.ts
+++ b/src/generators/docker/docker.test.ts
@@ -226,6 +226,28 @@ describe("generateDockerCompose", () => {
     expect(compose.endsWith("\n")).toBe(true);
   });
 
+  // PostgreSQL 18+ images keep data in a major-versioned subdirectory, so a mount
+  // at .../data is ignored and the container restart-loops on
+  // "in 18+, these Docker images are configured to store database data in a
+  // format which is compatible with pg_ctlcluster". The scaffold shipped exactly
+  // that for one release cycle.
+  it("mounts the database volume where PostgreSQL 18 actually stores data", async () => {
+    writeAuthEnvFixture(tmpDir, "SEAMLESS_JWKS_ACTIVE_KID");
+
+    await generateDockerCompose(tmpDir, {
+      authMode: "local",
+      adminMode: "image",
+    });
+
+    const compose = fs.readFileSync(
+      path.join(tmpDir, "docker-compose.yml"),
+      "utf-8",
+    );
+
+    expect(compose).toContain("- pgdata:/var/lib/postgresql\n");
+    expect(compose).not.toContain("/var/lib/postgresql/data");
+  });
+
   // Publishing on 0.0.0.0 put the auth server on the LAN, and it is configured to
   // hand back OTP codes in the response for local login.
   it("publishes every port on loopback only", async () => {

--- a/src/generators/docker/docker.ts
+++ b/src/generators/docker/docker.ts
@@ -72,7 +72,11 @@ services:
       POSTGRES_PASSWORD: mypassword
       POSTGRES_DB: postgres
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      # PostgreSQL 18+ images store data in a major-versioned subdirectory
+      # (/var/lib/postgresql/18/docker), so the mount goes one level up. Mounting
+      # .../data instead leaves the volume unused and the container refuses to
+      # start. See docker-library/postgres#1259.
+      - pgdata:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U myuser -d postgres"]
       interval: 5s


### PR DESCRIPTION
Fixes a defect introduced by #164, caught while doing the same bump in `seamless-templates` (fells-code/seamless-templates#42).

## The bug

#164 moved the image tag but not the volume mount. PostgreSQL 18+ images store data in a major-versioned subdirectory (`/var/lib/postgresql/18/docker`), so a mount at `/var/lib/postgresql/data` is ignored and the container refuses to start:

```
Error: in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" ...
       Counter to that, there appears to be PostgreSQL data in:
         /var/lib/postgresql/data (unused mount/volume)
```

It restart-loops. A project scaffolded from that change had a database that never came up. See docker-library/postgres#1259.

## Why CI missed it, and why that matters

The `verify / verify` job passed on #164 and I reported it as end-to-end proof. It wasn't. The harness's postgres service **mounts no volume at all**, so it used the new in-image default and worked fine. The broken artifact was the *generated* compose file, which nothing in CI ever stands up.

That is the real gap: `verify` exercises the running stack, not what `init` writes to disk. This PR closes the specific hole with a unit test asserting the generated mount path, but the general shape — a generated artifact no test executes — is worth a follow-up.

## Verified

Scaffolded a project with the built CLI and brought its database up:

- `running (healthy)`, `PostgreSQL 18.4 (Debian 18.4-1.pgdg13+1)`
- `PGDATA=/var/lib/postgresql/18/docker`, resolving inside the mounted volume
- wrote a row, `docker compose up -d --force-recreate db`, read it back: **survives**, so the volume is genuinely in use rather than data silently living in the container layer

Also reproduced the failure first with the old mount, so the test is against a real defect rather than a theory. `npm test` passes (816 passed, 4 skipped).

## Release impact

None shipped. 0.11.0 is on npm; the PostgreSQL 18 change is still sitting unreleased in the release PR (#163). This lands ahead of it, so no published version ever produced a broken scaffold.

## Related

The same mount change is needed everywhere else postgres moves to 18. The five issues I filed for the org rollout all say "bump the tag" and none mention the mount; I'm updating them now.